### PR TITLE
feat: use 600,000 gas limit for EVM chains, add Moca support

### DIFF
--- a/.changeset/jolly-cloths-train.md
+++ b/.changeset/jolly-cloths-train.md
@@ -1,0 +1,5 @@
+---
+"@m0-foundation/ntt-sdk-route": patch
+---
+
+use 600,000 gas limit for EVM chains, add Moca

--- a/scripts/bridge.ts
+++ b/scripts/bridge.ts
@@ -16,7 +16,7 @@ import "@wormhole-foundation/sdk-evm-ntt";
 import evmLoader from "@wormhole-foundation/sdk/evm";
 import solanaLoader from "@wormhole-foundation/sdk/solana";
 import "@wormhole-foundation/sdk-solana-ntt";
-import { M0AutomaticRoute } from "../src/m0AutomaticRoute";
+import { m0AutomaticRoute } from "../src/m0AutomaticRoute";
 
 const wM = {
   Solana: "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp",
@@ -53,7 +53,7 @@ async function bridge(params: {
   // get signers from env
   const srcSigner = await getSigner(src);
   const dstSigner = await getSigner(dst);
-  const resolver = wh.resolver([M0AutomaticRoute]);
+  const resolver = wh.resolver([m0AutomaticRoute()]);
 
   const tr = await routes.RouteTransferRequest.create(wh, {
     source: Wormhole.tokenId(params.sourceChain, params.sourceToken),

--- a/src/chainIds.ts
+++ b/src/chainIds.ts
@@ -24,6 +24,7 @@ export function getM0ChainId(chain: Chain, network: Network): number {
     Plume: 98866,
     Polygon: 137,
     Sei: 1329,
+    Moca: 2288,
     // Testnets
     ArbitrumSepolia: 421614,
     BaseSepolia: 84532,

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -8,8 +8,13 @@ export function getExecutorConfig(
   const svmChains: Chain[] = ["Solana"];
   const evmChains: Chain[] =
     network === "Mainnet"
-      ? ["Ethereum", "Arbitrum", "Base"]
+      ? ["Ethereum", "Arbitrum", "Base", "Moca"]
       : ["Sepolia", "ArbitrumSepolia", "BaseSepolia"];
+
+  const evmMToken = "0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b";
+  const evmOverrides = Object.fromEntries(
+    evmChains.map((chain) => [chain, { [evmMToken]: { gasLimit: 600_000n } }]),
+  );
 
   return {
     ntt: {
@@ -29,7 +34,7 @@ export function getExecutorConfig(
           })),
           ...evmChains.map((chain) => ({
             chain,
-            token: "0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b",
+            token: evmMToken,
             manager: "0xaCffEC28C4eEe21C889a4e6C0704c540Ed9D4fDd",
             transceiver: [
               {
@@ -50,11 +55,7 @@ export function getExecutorConfig(
             gasLimit: 450_000n,
           },
         },
-        Ethereum: {
-          ["0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b"]: {
-            gasLimit: 600_000n,
-          },
-        },
+        ...evmOverrides,
       },
     },
   };

--- a/src/m0AutomaticRoute.ts
+++ b/src/m0AutomaticRoute.ts
@@ -20,9 +20,9 @@ import {
   isRedeemed,
   isSourceFinalized,
   isSourceInitiated,
+  routes,
   signSendWait,
 } from "@wormhole-foundation/sdk-connect";
-import * as routes from "@wormhole-foundation/sdk-connect/routes";
 import { register as registerNttDefinitions } from "@wormhole-foundation/sdk-definitions-ntt";
 import { register as registerEvmNtt } from "@wormhole-foundation/sdk-evm-ntt";
 import { register as registerSolanaNtt } from "@wormhole-foundation/sdk-solana-ntt";
@@ -108,7 +108,7 @@ export class M0AutomaticRoute<N extends Network>
   static supportedChains(network: Network): Chain[] {
     switch (network) {
       case "Mainnet":
-        return ["Ethereum", "Arbitrum","Base", "Solana"];
+        return ["Ethereum", "Arbitrum", "Base", "Moca", "Solana"];
       case "Testnet":
         return [
           "Sepolia",
@@ -126,6 +126,7 @@ export class M0AutomaticRoute<N extends Network>
       case "Ethereum":
       case "Arbitrum":
       case "Base":
+      case "Moca":
       case "Sepolia":
       case "ArbitrumSepolia":
       case "BaseSepolia":


### PR DESCRIPTION
### Proposed Changes:
 - apply 600k gas limit to all EVM chains (was Ethereum-only).
 - add Moca support
 - fix type resolution for routes namespace
