### PR TITLE
feat: resolve bridging paths from Portal state (A: generated table)

### DIFF
--- a/.changeset/generated-supported-paths.md
+++ b/.changeset/generated-supported-paths.md
@@ -1,0 +1,14 @@
+---
+"@m0-foundation/ntt-sdk-route": minor
+---
+
+Only offer bridging paths the Portal actually accepts.
+
+Destination tokens are now resolved against `supportedBridgingPath` instead of a
+hardcoded token cross-product, and `validate()` re-checks the exact
+(source token, chain, destination token) triple before quoting. The candidate set
+is generated from live Portal state and refreshed daily.
+
+Also fixes `EvmRouter`/`SvmRouter` returning a router bound to the first chain
+touched, adds BSC to the chain id map, and makes `isAvailable()` honour the
+Portal's send pause.

--- a/.github/workflows/update-supported-paths.yaml
+++ b/.github/workflows/update-supported-paths.yaml
@@ -1,0 +1,147 @@
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-  .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-'   `-`-'   `-`-'
+#
+#      Refreshes src/generated/supportedPaths.ts from live Portal state
+#
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-  .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-'   `-`-'   `-`-'
+name: Update supported paths
+
+on:
+  schedule:
+    # 05:15 UTC daily — off the hour to avoid GitHub's scheduling peak.
+    - cron: "15 5 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Regenerate and show the diff without opening a PR"
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  NPM_TOKEN: ""
+
+jobs:
+  update:
+    name: Regenerate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Public RPCs are used for any chain without a secret. They are rate limited
+      # and often refuse wide getLogs ranges, which pushes those chains onto the
+      # probe fallback — set the secrets below for full log enumeration.
+      - name: Regenerate supported paths
+        run: pnpm generate:paths
+        env:
+          ETHEREUM_RPC_URL: ${{ secrets.ETHEREUM_RPC_URL }}
+          ARBITRUM_RPC_URL: ${{ secrets.ARBITRUM_RPC_URL }}
+          BASE_RPC_URL: ${{ secrets.BASE_RPC_URL }}
+          BSC_RPC_URL: ${{ secrets.BSC_RPC_URL }}
+          LINEA_RPC_URL: ${{ secrets.LINEA_RPC_URL }}
+          HYPER_EVM_RPC_URL: ${{ secrets.HYPER_EVM_RPC_URL }}
+          MONAD_RPC_URL: ${{ secrets.MONAD_RPC_URL }}
+          MOCA_RPC_URL: ${{ secrets.MOCA_RPC_URL }}
+          PLASMA_RPC_URL: ${{ secrets.PLASMA_RPC_URL }}
+          SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
+          ARBITRUM_SEPOLIA_RPC_URL: ${{ secrets.ARBITRUM_SEPOLIA_RPC_URL }}
+          BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL }}
+          OPTIMISM_SEPOLIA_RPC_URL: ${{ secrets.OPTIMISM_SEPOLIA_RPC_URL }}
+          SOLANA_RPC_URL: ${{ secrets.SOLANA_RPC_URL }}
+          SOLANA_DEVNET_RPC_URL: ${{ secrets.SOLANA_DEVNET_RPC_URL }}
+
+      # The build is the real check on the generated file: it must typecheck
+      # against the Chain union of the pinned SDK version.
+      - name: Build
+        run: pnpm build
+        env:
+          NODE_ENV: production
+
+      # Fails the run if what the SDK would offer differs from what the Portal
+      # accepts — the regenerated table is only useful if it is exact.
+      - name: Verify against on-chain state
+        run: pnpm verify:paths
+        env:
+          ETHEREUM_RPC_URL: ${{ secrets.ETHEREUM_RPC_URL }}
+          ARBITRUM_RPC_URL: ${{ secrets.ARBITRUM_RPC_URL }}
+          BASE_RPC_URL: ${{ secrets.BASE_RPC_URL }}
+          BSC_RPC_URL: ${{ secrets.BSC_RPC_URL }}
+          LINEA_RPC_URL: ${{ secrets.LINEA_RPC_URL }}
+          HYPER_EVM_RPC_URL: ${{ secrets.HYPER_EVM_RPC_URL }}
+          MONAD_RPC_URL: ${{ secrets.MONAD_RPC_URL }}
+          MOCA_RPC_URL: ${{ secrets.MOCA_RPC_URL }}
+          PLASMA_RPC_URL: ${{ secrets.PLASMA_RPC_URL }}
+          SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
+          ARBITRUM_SEPOLIA_RPC_URL: ${{ secrets.ARBITRUM_SEPOLIA_RPC_URL }}
+          BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL }}
+          OPTIMISM_SEPOLIA_RPC_URL: ${{ secrets.OPTIMISM_SEPOLIA_RPC_URL }}
+
+      - name: Check for changes
+        id: diff
+        run: |
+          # GENERATED_AT changes on every run; only a path or token change matters.
+          if git diff --quiet -- src/generated/supportedPaths.ts; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "$(git diff -U0 -- src/generated/supportedPaths.ts | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -v 'GENERATED_AT')" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Only the timestamp changed — discarding."
+            git checkout -- src/generated/supportedPaths.ts
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git --no-pager diff -- src/generated/supportedPaths.ts
+          fi
+
+      - name: Add changeset
+        if: steps.diff.outputs.changed == 'true' && !inputs.dry_run
+        run: |
+          mkdir -p .changeset
+          cat > .changeset/supported-paths-refresh.md <<'EOF'
+          ---
+          "@m0-foundation/ntt-sdk-route": patch
+          ---
+
+          Refresh generated supported bridging paths from live Portal state.
+          EOF
+
+      - name: Open pull request
+        if: steps.diff.outputs.changed == 'true' && !inputs.dry_run
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}
+          branch: chore/update-supported-paths
+          base: main
+          commit-message: "chore: refresh generated supported bridging paths"
+          title: "chore: refresh generated supported bridging paths"
+          body: |
+            Regenerated `src/generated/supportedPaths.ts` from live Portal state.
+
+            Source of truth is the Portal itself — `SupportedBridgingPathSet` logs on
+            EVM, `ChainBridgePaths` accounts on Solana. This file is generated; do not
+            hand-edit it. Review the diff for paths that were added or removed on-chain.
+
+            Check the job log for warnings: chains whose RPC would not serve a full log
+            history fall back to probing and can only find tokens already seen
+            elsewhere, and destinations with no Wormhole chain in the pinned SDK version
+            are dropped.
+          delete-branch: true
+          add-paths: |
+            src/generated/supportedPaths.ts
+            .changeset/supported-paths-refresh.md

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   "scripts": {
     "build": "$npm_execpath tsup --clean",
     "clean": "rm -rf dist",
-    "test-bridge": "node --env-file=.env -r ts-node/register scripts/bridge.ts"
+    "test-bridge": "node --env-file=.env -r ts-node/register scripts/bridge.ts",
+    "generate:paths": "ts-node scripts/fetch-supported-paths.ts",
+    "verify:paths": "ts-node scripts/verify-paths.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",

--- a/scripts/fetch-supported-paths.ts
+++ b/scripts/fetch-supported-paths.ts
@@ -1,0 +1,539 @@
+/**
+ * Regenerates `src/generated/supportedPaths.ts` from live chain state.
+ *
+ * Source of truth is the Portal itself:
+ *   - EVM    -> `SupportedBridgingPathSet(address,uint32,bytes32,bool)` logs, folded
+ *              in block order to the current value of each (src, dstChain, dstToken).
+ *   - Solana -> the Portal program's `ChainBridgePaths` accounts.
+ *
+ * Run:  pnpm generate:paths
+ * Never hand-edit the output.
+ */
+import { Chain, Network, chainToPlatform, chains } from "@wormhole-foundation/sdk-connect";
+import { Connection, PublicKey } from "@solana/web3.js";
+import { Contract, JsonRpcProvider, id as keccakId } from "ethers";
+import { writeFileSync } from "fs";
+import { join } from "path";
+import { getM0ChainId } from "../src/chainIds";
+
+const PORTAL_EVM = "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd";
+const PORTAL_SVM = new PublicKey("MzBrgc8yXBj4P16GTkcSyDZkEQZB9qDqf3fh9bByJce");
+const CHAIN_BRIDGE_PATHS_DISCRIMINATOR = Buffer.from([89, 30, 178, 53, 154, 232, 75, 140]);
+const PATH_SET_TOPIC = keccakId("SupportedBridgingPathSet(address,uint32,bytes32,bool)");
+
+/** Guardrails for chains whose RPC caps the getLogs block range. */
+const MAX_LOG_REQUESTS = Number(process.env.MAX_LOG_REQUESTS ?? 400);
+const LOG_CONCURRENCY = 8;
+
+const MULTICALL3 = "0xcA11bde05977b3631167028862bE2a173976CA11";
+const MULTICALL3_ABI = [
+  "function aggregate3((address target, bool allowFailure, bytes callData)[] calls) view returns ((bool success, bytes returnData)[])",
+];
+const PORTAL_ABI = ["function supportedBridgingPath(address,uint32,bytes32) view returns (bool)"];
+
+/** Present on every chain the Portal is deployed to; used for the probe fallback. */
+const PROBE_BATCH = 400;
+
+const ERC20_ABI = [
+  "function symbol() view returns (string)",
+  "function decimals() view returns (uint8)",
+];
+
+/**
+ * Chains the generator will scan. A chain only produces routes if it is also a
+ * Wormhole `Chain` — the route travels over the Wormhole adapter, so chains
+ * outside Wormhole's registry (Soneium, Citrea, Fluent, RISE, MANTRA, Seismic,
+ * Nexus, ...) can never be an endpoint here. Destinations that resolve to one of
+ * those are dropped and reported, never silently skipped.
+ */
+const SCAN: Record<Network, Chain[]> = {
+  Mainnet: ["Ethereum", "Arbitrum", "Base", "Moca", "Bsc", "Linea", "HyperEVM", "Monad", "Plasma", "Solana"],
+  Testnet: ["Sepolia", "ArbitrumSepolia", "BaseSepolia", "OptimismSepolia", "Solana"],
+  Devnet: [],
+};
+
+const PUBLIC_RPC: Partial<Record<Chain, string>> = {
+  Ethereum: "https://ethereum-rpc.publicnode.com",
+  Arbitrum: "https://arb1.arbitrum.io/rpc",
+  Base: "https://base-rpc.publicnode.com",
+  Bsc: "https://bsc-rpc.publicnode.com",
+  Linea: "https://linea-rpc.publicnode.com",
+  HyperEVM: "https://rpc.hyperliquid.xyz/evm",
+  Monad: "https://rpc.monad.xyz",
+  Plasma: "https://rpc.plasma.to",
+  Moca: "https://rpc.mocachain.org",
+  Sepolia: "https://ethereum-sepolia-rpc.publicnode.com",
+  ArbitrumSepolia: "https://sepolia-rollup.arbitrum.io/rpc",
+  BaseSepolia: "https://base-sepolia-rpc.publicnode.com",
+  OptimismSepolia: "https://optimism-sepolia-rpc.publicnode.com",
+};
+
+const SOLANA_RPC: Record<string, string> = {
+  Mainnet: process.env.SOLANA_RPC_URL ?? "https://api.mainnet-beta.solana.com",
+  Testnet: process.env.SOLANA_DEVNET_RPC_URL ?? "https://api.devnet.solana.com",
+};
+
+/** `ETHEREUM_RPC_URL`, `MOCA_RPC_URL`, `ARBITRUM_SEPOLIA_RPC_URL`, ... */
+function rpcEnvKey(chain: Chain): string {
+  return `${chain.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toUpperCase()}_RPC_URL`;
+}
+
+function rpcUrl(chain: Chain): string | undefined {
+  return process.env[rpcEnvKey(chain)] || PUBLIC_RPC[chain];
+}
+
+interface BridgePath {
+  sourceChain: Chain;
+  sourceToken: string;
+  destinationChain: Chain;
+  destinationToken: string;
+}
+
+interface TokenInfo {
+  symbol: string;
+  decimals: number;
+}
+
+const warnings: string[] = [];
+function warn(message: string) {
+  warnings.push(message);
+  console.warn(`  ! ${message}`);
+}
+
+/** M0 chain id -> Wormhole Chain, inverted from `getM0ChainId` over the scan set. */
+function m0ChainIdIndex(network: Network): Map<number, Chain> {
+  const index = new Map<number, Chain>();
+  for (const chain of chains) {
+    try {
+      index.set(getM0ChainId(chain, network), chain);
+    } catch {
+      // chain has no M0 id; not addressable by the Portal
+    }
+  }
+  return index;
+}
+
+/**
+ * Earliest block with code at `address`, by binary search. Returns 0 when the
+ * node has no archive state — scanning from genesis is slower but never misses
+ * an event, which matters more than the extra requests.
+ */
+async function deployBlock(provider: JsonRpcProvider, address: string, head: number): Promise<number> {
+  try {
+    if ((await provider.getCode(address, 0)) !== "0x") return 0;
+  } catch {
+    return 0; // no archive state
+  }
+
+  let lo = 0;
+  let hi = head;
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    let code: string;
+    try {
+      code = await provider.getCode(address, mid);
+    } catch {
+      return 0; // partial archive; fall back to a full scan
+    }
+    if (code === "0x") lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+type PathLog = { blockNumber: number; index: number; topics: readonly string[]; data: string };
+
+async function getLogsRange(provider: JsonRpcProvider, fromBlock: number, toBlock: number): Promise<PathLog[]> {
+  const logs = await provider.getLogs({ address: PORTAL_EVM, topics: [PATH_SET_TOPIC], fromBlock, toBlock });
+  return logs.map((l) => ({ blockNumber: l.blockNumber, index: l.index, topics: l.topics, data: l.data }));
+}
+
+/**
+ * Largest block span this RPC will accept for getLogs. Probed once per chain —
+ * providers differ by orders of magnitude (Alchemy serves the full chain in one
+ * call, Moca caps at 10k).
+ */
+async function maxLogSpan(provider: JsonRpcProvider, head: number): Promise<number> {
+  for (const span of [head + 1, 1_000_000, 100_000, 50_000, 10_000, 2_000]) {
+    if (span > head + 1) continue;
+    try {
+      await getLogsRange(provider, Math.max(head - span + 1, 0), head);
+      return span;
+    } catch {
+      // try a smaller span
+    }
+  }
+  return 1_000;
+}
+
+/** getLogs over [fromBlock, toBlock] in spans the provider accepts, run in parallel batches. */
+async function fetchPathLogs(provider: JsonRpcProvider, fromBlock: number, toBlock: number): Promise<PathLog[]> {
+  const span = await maxLogSpan(provider, toBlock);
+
+  const ranges: Array<[number, number]> = [];
+  for (let cursor = fromBlock; cursor <= toBlock; cursor += span) {
+    ranges.push([cursor, Math.min(cursor + span - 1, toBlock)]);
+  }
+  if (ranges.length > MAX_LOG_REQUESTS) {
+    throw new Error(
+      `would need ${ranges.length} getLogs calls at ${span} blocks/call (limit ${MAX_LOG_REQUESTS}) — ` +
+        `use an archive RPC with a larger range limit`,
+    );
+  }
+
+  const out: PathLog[] = [];
+  for (let i = 0; i < ranges.length; i += LOG_CONCURRENCY) {
+    const batch = ranges.slice(i, i + LOG_CONCURRENCY);
+    const results = await Promise.all(batch.map(([lo, hi]) => getLogsRange(provider, lo, hi)));
+    for (const r of results) out.push(...r);
+  }
+  return out;
+}
+
+/** bytes32 form of a destination token, matching the Portal's encoding. */
+function toBytes32(chain: Chain, token: string): string {
+  if (chainToPlatform(chain) === "Solana") {
+    return `0x${Buffer.from(new PublicKey(token).toBytes()).toString("hex")}`;
+  }
+  return `0x${token.replace(/^0x/, "").toLowerCase().padStart(64, "0")}`;
+}
+
+/**
+ * Fallback for chains whose RPC will not serve a full log history. Probes
+ * `supportedBridgingPath` for every (sourceToken, destinationChain, destinationToken)
+ * built from tokens already discovered elsewhere, batched through Multicall3.
+ *
+ * This can only see tokens that appear somewhere in the log-derived set, so it is
+ * strictly weaker than enumeration — it is a fallback, not an equal.
+ */
+async function probeEvmChain(
+  network: Network,
+  chain: Chain,
+  tokensByChain: Map<Chain, Set<string>>,
+  scanSet: Chain[],
+): Promise<BridgePath[]> {
+  const url = rpcUrl(chain);
+  if (!url) return [];
+
+  const provider = new JsonRpcProvider(url, undefined, { staticNetwork: true });
+  const multicall = new Contract(MULTICALL3, MULTICALL3_ABI, provider);
+  const portal = new Contract(PORTAL_EVM, PORTAL_ABI, provider);
+
+  if ((await provider.getCode(MULTICALL3)) === "0x") {
+    warn(`${chain}: Multicall3 not deployed — cannot probe`);
+    return [];
+  }
+
+  const sources = [...(tokensByChain.get(chain) ?? new Set<string>())];
+  if (sources.length === 0) {
+    warn(`${chain}: no candidate tokens discovered from other chains — no paths recorded`);
+    return [];
+  }
+
+  const candidates: BridgePath[] = [];
+  for (const sourceToken of sources) {
+    for (const destinationChain of scanSet) {
+      if (destinationChain === chain) continue;
+      for (const destinationToken of tokensByChain.get(destinationChain) ?? []) {
+        candidates.push({ sourceChain: chain, sourceToken, destinationChain, destinationToken });
+      }
+    }
+  }
+
+  const live: BridgePath[] = [];
+  for (let i = 0; i < candidates.length; i += PROBE_BATCH) {
+    const batch = candidates.slice(i, i + PROBE_BATCH);
+    const calls = batch.map((c) => ({
+      target: PORTAL_EVM,
+      allowFailure: true,
+      callData: portal.interface.encodeFunctionData("supportedBridgingPath", [
+        c.sourceToken,
+        getM0ChainId(c.destinationChain, network),
+        toBytes32(c.destinationChain, c.destinationToken),
+      ]),
+    }));
+    const results: Array<{ success: boolean; returnData: string }> = await multicall.aggregate3(calls);
+    results.forEach((r, j) => {
+      if (r.success && BigInt(r.returnData) === 1n) live.push(batch[j]!);
+    });
+  }
+
+  console.log(`  ${chain}: probed ${candidates.length} candidates, ${live.length} live paths (log fallback)`);
+  return live;
+}
+
+async function scanEvmChain(network: Network, chain: Chain, index: Map<number, Chain>): Promise<BridgePath[]> {
+  const url = rpcUrl(chain);
+  if (!url) {
+    warn(`${chain}: no RPC (set ${rpcEnvKey(chain)}) — skipped`);
+    return [];
+  }
+
+  const provider = new JsonRpcProvider(url, undefined, { staticNetwork: true });
+  if ((await provider.getCode(PORTAL_EVM)) === "0x") {
+    console.log(`  ${chain}: Portal not deployed — skipped`);
+    return [];
+  }
+
+  const head = await provider.getBlockNumber();
+  const start = await deployBlock(provider, PORTAL_EVM, head);
+  const logs = await fetchPathLogs(provider, start, head);
+
+  // Fold in block order; the last write for a key is its current value.
+  const state = new Map<string, { supported: boolean; path: Omit<BridgePath, "destinationChain"> & { destinationChainId: number } }>();
+  for (const log of logs.sort((a, b) => a.blockNumber - b.blockNumber || a.index - b.index)) {
+    const sourceToken = `0x${log.topics[1]!.slice(26)}`.toLowerCase();
+    const destinationChainId = Number(BigInt(log.topics[2]!));
+    const destinationTokenRaw = log.topics[3]!;
+    state.set(`${sourceToken}:${destinationChainId}:${destinationTokenRaw}`, {
+      supported: BigInt(log.data) === 1n,
+      path: { sourceChain: chain, sourceToken, destinationChainId, destinationToken: destinationTokenRaw },
+    });
+  }
+
+  const paths: BridgePath[] = [];
+  const dropped = new Set<number>();
+  for (const { supported, path } of state.values()) {
+    if (!supported) continue;
+    const destinationChain = index.get(path.destinationChainId);
+    if (!destinationChain) {
+      dropped.add(path.destinationChainId);
+      continue;
+    }
+    paths.push({
+      sourceChain: chain,
+      sourceToken: path.sourceToken,
+      destinationChain,
+      destinationToken: decodeDestinationToken(destinationChain, path.destinationToken),
+    });
+  }
+
+  console.log(`  ${chain}: ${logs.length} events, ${paths.length} live paths (from block ${start})`);
+  for (const id of [...dropped].sort((a, b) => a - b)) {
+    warn(`${chain}: live paths to M0 chain id ${id} dropped — no Wormhole chain in this SDK version`);
+  }
+  return paths;
+}
+
+function decodeDestinationToken(destinationChain: Chain, raw: string): string {
+  if (chainToPlatform(destinationChain) === "Solana") {
+    return new PublicKey(Buffer.from(raw.slice(2), "hex")).toBase58();
+  }
+  return `0x${raw.slice(26)}`.toLowerCase();
+}
+
+async function scanSolana(network: Network, index: Map<number, Chain>): Promise<BridgePath[]> {
+  const connection = new Connection(SOLANA_RPC[network]!, "confirmed");
+  const accounts = await connection.getProgramAccounts(PORTAL_SVM, {
+    filters: [{ memcmp: { offset: 0, bytes: bs58(CHAIN_BRIDGE_PATHS_DISCRIMINATOR) } }],
+  });
+
+  const paths: BridgePath[] = [];
+  const dropped = new Set<number>();
+  for (const { account } of accounts) {
+    const data = account.data;
+    let offset = 8 + 1; // discriminator + bump
+    const destinationChainId = data.readUInt32LE(offset);
+    offset += 4;
+    const count = data.readUInt32LE(offset);
+    offset += 4;
+
+    const destinationChain = index.get(destinationChainId);
+    for (let i = 0; i < count; i++) {
+      const sourceMint = new PublicKey(data.subarray(offset, offset + 32)).toBase58();
+      offset += 32;
+      const destinationToken = data.subarray(offset, offset + 32);
+      offset += 32;
+      if (!destinationChain) {
+        dropped.add(destinationChainId);
+        continue;
+      }
+      paths.push({
+        sourceChain: "Solana",
+        sourceToken: sourceMint,
+        destinationChain,
+        destinationToken: decodeDestinationToken(destinationChain, `0x${destinationToken.toString("hex")}`),
+      });
+    }
+  }
+
+  console.log(`  Solana: ${accounts.length} ChainBridgePaths accounts, ${paths.length} live paths`);
+  for (const id of [...dropped].sort((a, b) => a - b)) {
+    warn(`Solana: live paths to M0 chain id ${id} dropped — no Wormhole chain in this SDK version`);
+  }
+  return paths;
+}
+
+const B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+function bs58(buf: Buffer): string {
+  let n = BigInt(`0x${buf.toString("hex")}`);
+  let s = "";
+  while (n > 0n) {
+    s = B58[Number(n % 58n)] + s;
+    n /= 58n;
+  }
+  for (const b of buf) {
+    if (b !== 0) break;
+    s = `1${s}`;
+  }
+  return s;
+}
+
+/** symbol/decimals for every token that appears on either end of a live path. */
+async function fetchTokenInfo(network: Network, paths: BridgePath[]) {
+  const byChain = new Map<Chain, Set<string>>();
+  for (const p of paths) {
+    (byChain.get(p.sourceChain) ?? byChain.set(p.sourceChain, new Set()).get(p.sourceChain)!).add(p.sourceToken);
+    (byChain.get(p.destinationChain) ?? byChain.set(p.destinationChain, new Set()).get(p.destinationChain)!).add(p.destinationToken);
+  }
+
+  const info: Partial<Record<Chain, Record<string, TokenInfo>>> = {};
+  for (const [chain, tokens] of byChain) {
+    const entries: Record<string, TokenInfo> = {};
+    if (chainToPlatform(chain) === "Solana") {
+      const connection = new Connection(SOLANA_RPC[network]!, "confirmed");
+      for (const mint of tokens) {
+        try {
+          const parsed = await connection.getParsedAccountInfo(new PublicKey(mint));
+          const decimals = (parsed.value?.data as any)?.parsed?.info?.decimals;
+          entries[mint] = { symbol: "", decimals: typeof decimals === "number" ? decimals : 6 };
+        } catch {
+          warn(`Solana: could not read mint ${mint}`);
+        }
+      }
+    } else {
+      const url = rpcUrl(chain);
+      if (!url) continue;
+      const provider = new JsonRpcProvider(url, undefined, { staticNetwork: true });
+      for (const address of tokens) {
+        try {
+          const erc20 = new Contract(address, ERC20_ABI, provider);
+          const [symbol, decimals] = await Promise.all([erc20.symbol(), erc20.decimals()]);
+          entries[address] = { symbol: String(symbol), decimals: Number(decimals) };
+        } catch {
+          warn(`${chain}: could not read symbol/decimals for ${address}`);
+        }
+      }
+    }
+    info[chain] = Object.fromEntries(Object.entries(entries).sort(([a], [b]) => a.localeCompare(b)));
+  }
+  return info;
+}
+
+function sortPaths(paths: BridgePath[]): BridgePath[] {
+  return [...paths].sort(
+    (a, b) =>
+      a.sourceChain.localeCompare(b.sourceChain) ||
+      a.sourceToken.localeCompare(b.sourceToken) ||
+      a.destinationChain.localeCompare(b.destinationChain) ||
+      a.destinationToken.localeCompare(b.destinationToken),
+  );
+}
+
+function render(
+  pathsByNetwork: Record<string, BridgePath[]>,
+  infoByNetwork: Record<string, Partial<Record<Chain, Record<string, TokenInfo>>>>,
+  generatedAt: string,
+): string {
+  return `// GENERATED FILE — DO NOT EDIT.
+//
+// Regenerate with \`pnpm generate:paths\` (scripts/fetch-supported-paths.ts).
+// Refreshed daily by .github/workflows/update-supported-paths.yaml.
+//
+// Every entry was live on-chain at the time below. This table is the *candidate*
+// set only: the SDK re-checks each path against the Portal before offering it, so
+// a stale table can under-report but can never advertise a path that would revert.
+import { Chain } from "@wormhole-foundation/sdk-connect";
+
+export interface GeneratedBridgePath {
+  sourceChain: Chain;
+  /** EVM: lowercase 0x address. Solana: base58 mint. */
+  sourceToken: string;
+  destinationChain: Chain;
+  /** EVM: lowercase 0x address. Solana: base58 mint. */
+  destinationToken: string;
+}
+
+export interface GeneratedTokenInfo {
+  symbol: string;
+  decimals: number;
+}
+
+export const GENERATED_AT = ${JSON.stringify(generatedAt)};
+
+export const SUPPORTED_PATHS: Record<string, GeneratedBridgePath[]> = ${JSON.stringify(pathsByNetwork, null, 2)};
+
+export const TOKEN_INFO: Record<string, Partial<Record<Chain, Record<string, GeneratedTokenInfo>>>> = ${JSON.stringify(infoByNetwork, null, 2)};
+`;
+}
+
+async function main() {
+  const generatedAt = new Date().toISOString();
+  const pathsByNetwork: Record<string, BridgePath[]> = {};
+  const infoByNetwork: Record<string, Partial<Record<Chain, Record<string, TokenInfo>>>> = {};
+
+  for (const network of ["Mainnet", "Testnet"] as Network[]) {
+    console.log(`\n${network}`);
+    const index = m0ChainIdIndex(network);
+    const collected: BridgePath[] = [];
+
+    const needsProbe: Chain[] = [];
+    for (const chain of SCAN[network]) {
+      try {
+        collected.push(
+          ...(chainToPlatform(chain) === "Solana"
+            ? await scanSolana(network, index)
+            : await scanEvmChain(network, chain, index)),
+        );
+      } catch (e) {
+        warn(`${chain}: log enumeration unavailable (${(e as Error).message}) — falling back to probing`);
+        needsProbe.push(chain);
+      }
+    }
+
+    // Second pass: chains whose RPC would not serve a full log history. Their
+    // candidate tokens come from what the first pass already saw on that chain.
+    if (needsProbe.length) {
+      const tokensByChain = new Map<Chain, Set<string>>();
+      const note = (chain: Chain, token: string) =>
+        (tokensByChain.get(chain) ?? tokensByChain.set(chain, new Set()).get(chain)!).add(token);
+      for (const p of collected) {
+        note(p.sourceChain, p.sourceToken);
+        note(p.destinationChain, p.destinationToken);
+      }
+      for (const chain of needsProbe) {
+        try {
+          collected.push(...(await probeEvmChain(network, chain, tokensByChain, SCAN[network])));
+        } catch (e) {
+          warn(`${chain}: probe failed — ${(e as Error).message}`);
+        }
+      }
+    }
+
+    // A path is only usable if both endpoints are chains this route supports.
+    const inScope = new Set(SCAN[network]);
+    const usable = collected.filter((p) => {
+      if (inScope.has(p.destinationChain)) return true;
+      warn(`${p.sourceChain}: path to ${p.destinationChain} dropped — destination not in the scan set`);
+      return false;
+    });
+
+    pathsByNetwork[network] = sortPaths(usable);
+    infoByNetwork[network] = await fetchTokenInfo(network, usable);
+    console.log(`  => ${usable.length} usable paths on ${network}`);
+  }
+
+  const target = join(__dirname, "..", "src", "generated", "supportedPaths.ts");
+  writeFileSync(target, render(pathsByNetwork, infoByNetwork, generatedAt));
+  console.log(`\nWrote ${target}`);
+
+  if (warnings.length) {
+    console.log(`\n${warnings.length} warning(s):`);
+    for (const w of warnings) console.log(`  - ${w}`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/verify-paths.ts
+++ b/scripts/verify-paths.ts
@@ -1,0 +1,121 @@
+/**
+ * Checks that what the SDK offers equals what the Portal accepts.
+ *
+ * For every (source chain, source token, destination chain) the SDK can produce,
+ * compares `EvmRouter.getSupportedDestinationTokens` against a direct
+ * `supportedBridgingPath` read. Any difference is a bug: extra entries would be
+ * offered to users and revert, missing entries are routes silently withheld.
+ *
+ * Run:  pnpm verify:paths
+ */
+import { Chain, chainToPlatform, Network } from "@wormhole-foundation/sdk-connect";
+import { Contract, JsonRpcProvider } from "ethers";
+import { PublicKey } from "@solana/web3.js";
+// Registers the platform address types that `toNative` needs.
+import "@wormhole-foundation/sdk-evm";
+import "@wormhole-foundation/sdk-solana";
+import { EvmRouter } from "../src/evm";
+import { getM0ChainId } from "../src/chainIds";
+import { knownChains, knownSourceTokens, knownTokensOn } from "../src/paths";
+import { GENERATED_AT } from "../src/generated/supportedPaths";
+
+const PORTAL = "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd";
+const PORTAL_ABI = ["function supportedBridgingPath(address,uint32,bytes32) view returns (bool)"];
+
+const PUBLIC_RPC: Partial<Record<Chain, string>> = {
+  Ethereum: "https://ethereum-rpc.publicnode.com",
+  Arbitrum: "https://arb1.arbitrum.io/rpc",
+  Base: "https://base-rpc.publicnode.com",
+  Bsc: "https://bsc-rpc.publicnode.com",
+  Linea: "https://linea-rpc.publicnode.com",
+  HyperEVM: "https://rpc.hyperliquid.xyz/evm",
+  Monad: "https://rpc.monad.xyz",
+  Plasma: "https://rpc.plasma.to",
+  Moca: "https://rpc.mocachain.org",
+  Sepolia: "https://ethereum-sepolia-rpc.publicnode.com",
+  ArbitrumSepolia: "https://sepolia-rollup.arbitrum.io/rpc",
+  BaseSepolia: "https://base-sepolia-rpc.publicnode.com",
+  OptimismSepolia: "https://optimism-sepolia-rpc.publicnode.com",
+};
+
+function rpcUrl(chain: Chain): string | undefined {
+  const key = `${chain.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toUpperCase()}_RPC_URL`;
+  return process.env[key] || PUBLIC_RPC[chain];
+}
+
+function toBytes32(chain: Chain, token: string): string {
+  if (chainToPlatform(chain) === "Solana") {
+    return `0x${Buffer.from(new PublicKey(token).toBytes()).toString("hex")}`;
+  }
+  return `0x${token.replace(/^0x/, "").toLowerCase().padStart(64, "0")}`;
+}
+
+async function verifyNetwork(network: Network): Promise<number> {
+  console.log(`\n${network} (table generated ${GENERATED_AT})`);
+  let pairs = 0;
+  let offered = 0;
+  let mismatches = 0;
+
+  for (const chain of knownChains(network).filter((c) => chainToPlatform(c) === "Evm")) {
+    const url = rpcUrl(chain);
+    if (!url) {
+      console.log(`  ${chain}: no RPC — skipped`);
+      continue;
+    }
+
+    const provider = new JsonRpcProvider(url, undefined, { staticNetwork: true });
+    const router = new EvmRouter(provider, chain, network as Exclude<Network, "Devnet">);
+    const portal = new Contract(PORTAL, PORTAL_ABI, provider);
+
+    for (const sourceToken of knownSourceTokens(network, chain)) {
+      for (const toChain of knownChains(network)) {
+        if (toChain === chain) continue;
+
+        const sdk = (await router.getSupportedDestinationTokens(sourceToken, toChain))
+          .map((t) => t.address.toString().toLowerCase())
+          .sort();
+
+        const onChain: string[] = [];
+        for (const candidate of knownTokensOn(network, toChain)) {
+          const supported: boolean = await portal.supportedBridgingPath(
+            sourceToken,
+            getM0ChainId(toChain, network),
+            toBytes32(toChain, candidate),
+          );
+          if (supported) onChain.push(candidate.toLowerCase());
+        }
+        onChain.sort();
+
+        pairs++;
+        offered += sdk.length;
+        if (JSON.stringify(sdk) !== JSON.stringify(onChain)) {
+          mismatches++;
+          console.log(`  MISMATCH ${chain}:${sourceToken} -> ${toChain}`);
+          console.log(`     sdk      ${JSON.stringify(sdk)}`);
+          console.log(`     on-chain ${JSON.stringify(onChain)}`);
+        }
+      }
+    }
+    console.log(`  ${chain}: ok`);
+  }
+
+  console.log(`  pairs checked ${pairs}, destination tokens offered ${offered}, mismatches ${mismatches}`);
+  return mismatches;
+}
+
+async function main() {
+  let mismatches = 0;
+  for (const network of ["Mainnet", "Testnet"] as Network[]) {
+    mismatches += await verifyNetwork(network);
+  }
+  if (mismatches > 0) {
+    console.error(`\n${mismatches} mismatch(es) between the SDK and on-chain state`);
+    process.exit(1);
+  }
+  console.log("\nSDK output matches on-chain state exactly.");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/chainIds.ts
+++ b/src/chainIds.ts
@@ -12,6 +12,7 @@ export function getM0ChainId(chain: Chain, network: Network): number {
     Avalanche: 43114,
     Base: 8453,
     Berachain: 80094,
+    Bsc: 56,
     Ethereum: 1,
     HyperEVM: 999,
     Ink: 57073,

--- a/src/evm.ts
+++ b/src/evm.ts
@@ -4,31 +4,39 @@ import {
   chainToPlatform,
   Network,
   TokenId,
-  toNative,
 } from "@wormhole-foundation/sdk-connect";
 import { Contract, ContractTransaction, type Provider } from "ethers";
 import { evmPortalProvider } from "./artifacts";
 import { getM0ChainId } from "./chainIds";
 import { NttWithExecutor } from "@wormhole-foundation/sdk-definitions-ntt";
 import { PublicKey } from "@solana/web3.js";
+import { knownSourceTokens, knownTokensOn, toTokenIds } from "./paths";
 
 const ERC20_ABI = [
   "function allowance(address owner, address spender) view returns (uint256)",
   "function approve(address spender, uint256 amount) returns (bool)",
 ];
 
+const MULTICALL3_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11";
+const MULTICALL3_ABI = [
+  "function aggregate3((address target, bool allowFailure, bytes callData)[] calls) view returns ((bool success, bytes returnData)[])",
+];
+
+/** How long a resolved destination-token set stays warm. */
+const PATH_CACHE_TTL_MS = 30_000;
+
 export class EvmRouter {
-  private static instance: EvmRouter | null = null;
+  /**
+   * One router per (network, chain). A bare singleton would hand the second chain
+   * touched a provider bound to the first, silently reading balances and
+   * allowances from the wrong chain.
+   */
+  private static instances = new Map<string, EvmRouter>();
 
   private WORMHOLE_ADAPTER = "0xaCffEC28C4eEe21C889a4e6C0704c540Ed9D4fDd";
   private static PORTAL_ADDRESS = "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd";
 
-  private TOKENS = [
-    "0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b", // $M
-    "0xdb1C440386b864181C77c02A51b7f4F6dD840dF4", // $MM
-    "0x437cc33344a0B27A429f795ff6B469C72698B291", // wM
-    "0xA4B6DF229AEe22b4252dc578FEB2720E8A2C4A56", // USDZ
-  ];
+  private pathCache = new Map<string, { expiresAt: number; tokens: string[] }>();
 
   constructor(
     private provider: Provider,
@@ -36,46 +44,119 @@ export class EvmRouter {
     public network: Exclude<Network, "Devnet">,
   ) {}
 
-  async getSupportedSourceTokens(): Promise<TokenId[]> {
-    return this.TOKENS.map((token) => ({
-      chain: this.chain,
-      address: toNative(this.chain, token),
-    }));
-  }
-
-  async getSupportedDestinationTokens(
-    _sourceToken: string,
-    toChain: Chain,
-  ): Promise<TokenId[]> {
-    if (toChain === "Solana") {
-      return [
-        {
-          chain: toChain,
-          address: toNative(toChain, "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"),
-        },
-      ];
-    }
-
-    return this.TOKENS.map((token) => ({
-      chain: toChain,
-      address: toNative(toChain, token),
-    }));
-  }
-
   static async fromChainContext(ctx: ChainContext<Network>) {
     if (chainToPlatform(ctx.chain) !== "Evm") {
       throw new Error(`Unsupported evm chain: ${ctx.chain}`);
     }
 
-    if (!EvmRouter.instance) {
-      EvmRouter.instance = new EvmRouter(
+    const key = `${ctx.network}:${ctx.chain}`;
+    let instance = EvmRouter.instances.get(key);
+    if (!instance) {
+      instance = new EvmRouter(
         await ctx.getRpc(),
         ctx.chain,
         ctx.network as Exclude<Network, "Devnet">,
       );
+      EvmRouter.instances.set(key, instance);
     }
 
-    return EvmRouter.instance;
+    return instance;
+  }
+
+  async getSupportedSourceTokens(): Promise<TokenId[]> {
+    return toTokenIds(this.chain, knownSourceTokens(this.network, this.chain));
+  }
+
+  /**
+   * Destination tokens the Portal will actually accept for `sourceToken`.
+   *
+   * Candidates come from the generated table; the answer comes from the Portal.
+   * `Portal.sendToken` reverts with `UnsupportedBridgingPath` for anything not
+   * registered, so returning an unchecked list makes the route resolve for
+   * transfers that cannot succeed.
+   */
+  async getSupportedDestinationTokens(
+    sourceToken: string,
+    toChain: Chain,
+  ): Promise<TokenId[]> {
+    const cacheKey = `${sourceToken.toLowerCase()}:${toChain}`;
+    const cached = this.pathCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return toTokenIds(toChain, cached.tokens);
+    }
+
+    const candidates = knownTokensOn(this.network, toChain);
+    if (candidates.length === 0) return [];
+
+    const supported = await this.filterSupportedPaths(sourceToken, toChain, candidates);
+    this.pathCache.set(cacheKey, {
+      expiresAt: Date.now() + PATH_CACHE_TTL_MS,
+      tokens: supported,
+    });
+
+    return toTokenIds(toChain, supported);
+  }
+
+  /** Narrows `candidates` to those registered on the Portal, in one Multicall3 round trip. */
+  async filterSupportedPaths(
+    sourceToken: string,
+    toChain: Chain,
+    candidates: string[],
+  ): Promise<string[]> {
+    const portal = evmPortalProvider(this.provider);
+    const destinationChainId = getM0ChainId(toChain, this.network);
+
+    const calls = candidates.map((token) => ({
+      target: EvmRouter.PORTAL_ADDRESS,
+      allowFailure: true,
+      callData: portal.interface.encodeFunctionData("supportedBridgingPath", [
+        sourceToken,
+        destinationChainId,
+        EvmRouter.stringToBytes32(token),
+      ]),
+    }));
+
+    try {
+      const multicall = new Contract(MULTICALL3_ADDRESS, MULTICALL3_ABI, this.provider);
+      const results: Array<{ success: boolean; returnData: string }> =
+        await multicall.aggregate3(calls);
+      return candidates.filter((_, i) => {
+        const result = results[i];
+        return !!result?.success && BigInt(result.returnData) === 1n;
+      });
+    } catch {
+      // No Multicall3, or the call was rejected — fall back to individual reads
+      // rather than returning an unchecked list.
+      const checks = await Promise.all(
+        candidates.map((token) => this.isSupportedPath(sourceToken, toChain, token)),
+      );
+      return candidates.filter((_, i) => checks[i]);
+    }
+  }
+
+  /** Single-path check, used to gate a transfer immediately before quoting it. */
+  async isSupportedPath(
+    sourceToken: string,
+    toChain: Chain,
+    destinationToken: string,
+  ): Promise<boolean> {
+    try {
+      return await evmPortalProvider(this.provider).supportedBridgingPath(
+        sourceToken,
+        getM0ChainId(toChain, this.network),
+        EvmRouter.stringToBytes32(destinationToken),
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  async isSendPaused(): Promise<boolean> {
+    try {
+      return await evmPortalProvider(this.provider).sendPaused();
+    } catch {
+      return false;
+    }
   }
 
   async buildSendTokenTransaction(
@@ -89,7 +170,6 @@ export class EvmRouter {
   ): Promise<ContractTransaction> {
     const portal = evmPortalProvider(this.provider);
 
-    const recipientBytes32 = EvmRouter.stringToBytes32(recipient);
     const destinationTokenBytes32 = EvmRouter.stringToBytes32(destinationToken);
 
     const tx = await portal

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,15 +1,17 @@
 import { Chain, Network } from "@wormhole-foundation/sdk-connect";
 import { NttExecutorRoute, NttRoute } from "@wormhole-foundation/sdk-route-ntt";
 import { PublicKey } from "@solana/web3.js";
+import { chainToPlatform } from "@wormhole-foundation/sdk-connect";
+import { knownChains } from "./paths";
 
 export function getExecutorConfig(
   network: Network = "Mainnet",
 ): NttExecutorRoute.Config {
-  const svmChains: Chain[] = ["Solana"];
-  const evmChains: Chain[] =
-    network === "Mainnet"
-      ? ["Ethereum", "Arbitrum", "Base", "Moca"]
-      : ["Sepolia", "ArbitrumSepolia", "BaseSepolia"];
+  // Derived from the generated path table so this cannot drift from
+  // `M0AutomaticRoute.supportedChains`.
+  const supported = knownChains(network);
+  const svmChains: Chain[] = supported.filter((c) => chainToPlatform(c) === "Solana");
+  const evmChains: Chain[] = supported.filter((c) => chainToPlatform(c) === "Evm");
 
   const evmMToken = "0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b";
   const evmOverrides = Object.fromEntries(

--- a/src/generated/supportedPaths.ts
+++ b/src/generated/supportedPaths.ts
@@ -1,0 +1,1093 @@
+// GENERATED FILE — DO NOT EDIT.
+//
+// Regenerate with `pnpm generate:paths` (scripts/fetch-supported-paths.ts).
+// Refreshed daily by .github/workflows/update-supported-paths.yaml.
+//
+// Every entry was live on-chain at the time below. This table is the *candidate*
+// set only: the SDK re-checks each path against the Portal before offering it, so
+// a stale table can under-report but can never advertise a path that would revert.
+import { Chain } from "@wormhole-foundation/sdk-connect";
+
+export interface GeneratedBridgePath {
+  sourceChain: Chain;
+  /** EVM: lowercase 0x address. Solana: base58 mint. */
+  sourceToken: string;
+  destinationChain: Chain;
+  /** EVM: lowercase 0x address. Solana: base58 mint. */
+  destinationToken: string;
+}
+
+export interface GeneratedTokenInfo {
+  symbol: string;
+  decimals: number;
+}
+
+export const GENERATED_AT = "2026-08-19T12:11:44.680Z";
+
+export const SUPPORTED_PATHS: Record<string, GeneratedBridgePath[]> = {
+  "Mainnet": [
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Base",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Base",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0xa4b6df229aee22b4252dc578feb2720e8a2c4a56"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "mzerokyEX9TNDoK4o2YZQBDmMzjokAeN6M2g2S3pLJo"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "usdkbee86pkLyRmxfFCdkyySpxRb5ndCxVsK2BkRXwX"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "usdkyPPxgV7sfNyKb8eDz66ogPrkRXG3wS2FVb6LLUf"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Base",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Base",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "mzerokyEX9TNDoK4o2YZQBDmMzjokAeN6M2g2S3pLJo"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "usdkbee86pkLyRmxfFCdkyySpxRb5ndCxVsK2BkRXwX"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "usdkyPPxgV7sfNyKb8eDz66ogPrkRXG3wS2FVb6LLUf"
+    },
+    {
+      "sourceChain": "Arbitrum",
+      "sourceToken": "0xa4b6df229aee22b4252dc578feb2720e8a2c4a56",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0xa4b6df229aee22b4252dc578feb2720e8a2c4a56"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Arbitrum",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Arbitrum",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroZRGCah3j5xEWp2Nih3GDejSBbH1rbHoxDg8By6"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "usdkbee86pkLyRmxfFCdkyySpxRb5ndCxVsK2BkRXwX"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "usdkyPPxgV7sfNyKb8eDz66ogPrkRXG3wS2FVb6LLUf"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Arbitrum",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Arbitrum",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroZRGCah3j5xEWp2Nih3GDejSBbH1rbHoxDg8By6"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "usdkbee86pkLyRmxfFCdkyySpxRb5ndCxVsK2BkRXwX"
+    },
+    {
+      "sourceChain": "Base",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "usdkyPPxgV7sfNyKb8eDz66ogPrkRXG3wS2FVb6LLUf"
+    },
+    {
+      "sourceChain": "Bsc",
+      "sourceToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da"
+    },
+    {
+      "sourceChain": "Bsc",
+      "sourceToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da",
+      "destinationChain": "Linea",
+      "destinationToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da"
+    },
+    {
+      "sourceChain": "Bsc",
+      "sourceToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da",
+      "destinationChain": "Monad",
+      "destinationToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Arbitrum",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Arbitrum",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Arbitrum",
+      "destinationToken": "0xa4b6df229aee22b4252dc578feb2720e8a2c4a56"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Base",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Base",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "HyperEVM",
+      "destinationToken": "0xb50a96253abdf803d85efcdce07ad8becbc52bd5"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Moca",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "mzerokyEX9TNDoK4o2YZQBDmMzjokAeN6M2g2S3pLJo"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "usdkbee86pkLyRmxfFCdkyySpxRb5ndCxVsK2BkRXwX"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "usdkyPPxgV7sfNyKb8eDz66ogPrkRXG3wS2FVb6LLUf"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Arbitrum",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Arbitrum",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Base",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Base",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Moca",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Moca",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Monad",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "mzerokyEX9TNDoK4o2YZQBDmMzjokAeN6M2g2S3pLJo"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "usdkbee86pkLyRmxfFCdkyySpxRb5ndCxVsK2BkRXwX"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "usdkyPPxgV7sfNyKb8eDz66ogPrkRXG3wS2FVb6LLUf"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "xoUSD7HdezER6vVPbYETEpPR3G7CsCgzWioiDezxDsg"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "xoUSDGZKvRqNK11R4KwYofahwCybp9VXTjuvRDSjFsV"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0xa4b6df229aee22b4252dc578feb2720e8a2c4a56",
+      "destinationChain": "Arbitrum",
+      "destinationToken": "0xa4b6df229aee22b4252dc578feb2720e8a2c4a56"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da",
+      "destinationChain": "Bsc",
+      "destinationToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da",
+      "destinationChain": "Linea",
+      "destinationToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da",
+      "destinationChain": "Monad",
+      "destinationToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0xdb1c440386b864181c77c02a51b7f4f6dd840df4",
+      "destinationChain": "Moca",
+      "destinationToken": "0x911c64b221d3509f4fe27a352d12d8a0615d0674"
+    },
+    {
+      "sourceChain": "Ethereum",
+      "sourceToken": "0xdb1c440386b864181c77c02a51b7f4f6dd840df4",
+      "destinationChain": "Solana",
+      "destinationToken": "xoUSDq85Rjsb6SbUwJyreFgeWQvxdkT7R3c3g7s6p5Y"
+    },
+    {
+      "sourceChain": "HyperEVM",
+      "sourceToken": "0xb50a96253abdf803d85efcdce07ad8becbc52bd5",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Linea",
+      "sourceToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da",
+      "destinationChain": "Bsc",
+      "destinationToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da"
+    },
+    {
+      "sourceChain": "Linea",
+      "sourceToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da"
+    },
+    {
+      "sourceChain": "Linea",
+      "sourceToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da",
+      "destinationChain": "Monad",
+      "destinationToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da"
+    },
+    {
+      "sourceChain": "Moca",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Moca",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Moca",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Moca",
+      "sourceToken": "0x911c64b221d3509f4fe27a352d12d8a0615d0674",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0xdb1c440386b864181c77c02a51b7f4f6dd840df4"
+    },
+    {
+      "sourceChain": "Monad",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Monad",
+      "sourceToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da",
+      "destinationChain": "Bsc",
+      "destinationToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da"
+    },
+    {
+      "sourceChain": "Monad",
+      "sourceToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da"
+    },
+    {
+      "sourceChain": "Monad",
+      "sourceToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da",
+      "destinationChain": "Linea",
+      "destinationToken": "0xaca92e438df0b2401ff60da7e4337b687a2435da"
+    },
+    {
+      "sourceChain": "Solana",
+      "sourceToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Solana",
+      "sourceToken": "xoUSDq85Rjsb6SbUwJyreFgeWQvxdkT7R3c3g7s6p5Y",
+      "destinationChain": "Ethereum",
+      "destinationToken": "0xdb1c440386b864181c77c02a51b7f4f6dd840df4"
+    }
+  ],
+  "Testnet": [
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "BaseSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "BaseSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "OptimismSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "OptimismSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Sepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Sepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"
+    },
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroZRGCah3j5xEWp2Nih3GDejSBbH1rbHoxDg8By6"
+    },
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "BaseSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "BaseSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "OptimismSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "OptimismSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Sepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Sepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"
+    },
+    {
+      "sourceChain": "ArbitrumSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroZRGCah3j5xEWp2Nih3GDejSBbH1rbHoxDg8By6"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "ArbitrumSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "ArbitrumSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "OptimismSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "OptimismSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Sepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Sepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroZRGCah3j5xEWp2Nih3GDejSBbH1rbHoxDg8By6"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "ArbitrumSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "ArbitrumSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "OptimismSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "OptimismSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Sepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Sepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"
+    },
+    {
+      "sourceChain": "BaseSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroZRGCah3j5xEWp2Nih3GDejSBbH1rbHoxDg8By6"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "ArbitrumSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "ArbitrumSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "BaseSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "BaseSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Sepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Sepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroZRGCah3j5xEWp2Nih3GDejSBbH1rbHoxDg8By6"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "ArbitrumSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "ArbitrumSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "BaseSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "BaseSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Sepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Sepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"
+    },
+    {
+      "sourceChain": "OptimismSepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroZRGCah3j5xEWp2Nih3GDejSBbH1rbHoxDg8By6"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "ArbitrumSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "ArbitrumSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "BaseSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "BaseSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "OptimismSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "OptimismSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x437cc33344a0b27a429f795ff6b469c72698b291",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroZRGCah3j5xEWp2Nih3GDejSBbH1rbHoxDg8By6"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "ArbitrumSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "ArbitrumSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "BaseSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "BaseSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "OptimismSepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "OptimismSepolia",
+      "destinationToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"
+    },
+    {
+      "sourceChain": "Sepolia",
+      "sourceToken": "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b",
+      "destinationChain": "Solana",
+      "destinationToken": "mzeroZRGCah3j5xEWp2Nih3GDejSBbH1rbHoxDg8By6"
+    },
+    {
+      "sourceChain": "Solana",
+      "sourceToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp",
+      "destinationChain": "Sepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    },
+    {
+      "sourceChain": "Solana",
+      "sourceToken": "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp",
+      "destinationChain": "Sepolia",
+      "destinationToken": "0x437cc33344a0b27a429f795ff6b469c72698b291"
+    }
+  ]
+};
+
+export const TOKEN_INFO: Record<string, Partial<Record<Chain, Record<string, GeneratedTokenInfo>>>> = {
+  "Mainnet": {
+    "Ethereum": {
+      "0x437cc33344a0b27a429f795ff6b469c72698b291": {
+        "symbol": "wM",
+        "decimals": 6
+      },
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b": {
+        "symbol": "M",
+        "decimals": 6
+      },
+      "0xa4b6df229aee22b4252dc578feb2720e8a2c4a56": {
+        "symbol": "USDZ",
+        "decimals": 6
+      },
+      "0xaca92e438df0b2401ff60da7e4337b687a2435da": {
+        "symbol": "mUSD",
+        "decimals": 6
+      },
+      "0xdb1c440386b864181c77c02a51b7f4f6dd840df4": {
+        "symbol": "MM",
+        "decimals": 6
+      }
+    },
+    "Arbitrum": {
+      "0x437cc33344a0b27a429f795ff6b469c72698b291": {
+        "symbol": "wM",
+        "decimals": 6
+      },
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b": {
+        "symbol": "M",
+        "decimals": 6
+      },
+      "0xa4b6df229aee22b4252dc578feb2720e8a2c4a56": {
+        "symbol": "USDZ",
+        "decimals": 6
+      }
+    },
+    "Solana": {
+      "mzerokyEX9TNDoK4o2YZQBDmMzjokAeN6M2g2S3pLJo": {
+        "symbol": "",
+        "decimals": 6
+      },
+      "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp": {
+        "symbol": "",
+        "decimals": 6
+      },
+      "mzeroZRGCah3j5xEWp2Nih3GDejSBbH1rbHoxDg8By6": {
+        "symbol": "",
+        "decimals": 6
+      },
+      "usdkbee86pkLyRmxfFCdkyySpxRb5ndCxVsK2BkRXwX": {
+        "symbol": "",
+        "decimals": 6
+      },
+      "usdkyPPxgV7sfNyKb8eDz66ogPrkRXG3wS2FVb6LLUf": {
+        "symbol": "",
+        "decimals": 6
+      },
+      "xoUSD7HdezER6vVPbYETEpPR3G7CsCgzWioiDezxDsg": {
+        "symbol": "",
+        "decimals": 6
+      },
+      "xoUSDGZKvRqNK11R4KwYofahwCybp9VXTjuvRDSjFsV": {
+        "symbol": "",
+        "decimals": 6
+      },
+      "xoUSDq85Rjsb6SbUwJyreFgeWQvxdkT7R3c3g7s6p5Y": {
+        "symbol": "",
+        "decimals": 6
+      }
+    },
+    "Base": {
+      "0x437cc33344a0b27a429f795ff6b469c72698b291": {
+        "symbol": "wM",
+        "decimals": 6
+      },
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b": {
+        "symbol": "M",
+        "decimals": 6
+      }
+    },
+    "Moca": {
+      "0x437cc33344a0b27a429f795ff6b469c72698b291": {
+        "symbol": "wM",
+        "decimals": 6
+      },
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b": {
+        "symbol": "M",
+        "decimals": 6
+      },
+      "0x911c64b221d3509f4fe27a352d12d8a0615d0674": {
+        "symbol": "USD8",
+        "decimals": 6
+      }
+    },
+    "Monad": {
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b": {
+        "symbol": "M",
+        "decimals": 6
+      },
+      "0xaca92e438df0b2401ff60da7e4337b687a2435da": {
+        "symbol": "mUSD",
+        "decimals": 6
+      }
+    },
+    "HyperEVM": {
+      "0xb50a96253abdf803d85efcdce07ad8becbc52bd5": {
+        "symbol": "USDHL",
+        "decimals": 6
+      }
+    },
+    "Bsc": {
+      "0xaca92e438df0b2401ff60da7e4337b687a2435da": {
+        "symbol": "mUSD",
+        "decimals": 6
+      }
+    },
+    "Linea": {
+      "0xaca92e438df0b2401ff60da7e4337b687a2435da": {
+        "symbol": "mUSD",
+        "decimals": 6
+      }
+    }
+  },
+  "Testnet": {
+    "Sepolia": {
+      "0x437cc33344a0b27a429f795ff6b469c72698b291": {
+        "symbol": "wM",
+        "decimals": 6
+      },
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b": {
+        "symbol": "M",
+        "decimals": 6
+      }
+    },
+    "ArbitrumSepolia": {
+      "0x437cc33344a0b27a429f795ff6b469c72698b291": {
+        "symbol": "wM",
+        "decimals": 6
+      },
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b": {
+        "symbol": "M",
+        "decimals": 6
+      }
+    },
+    "OptimismSepolia": {
+      "0x437cc33344a0b27a429f795ff6b469c72698b291": {
+        "symbol": "wM",
+        "decimals": 6
+      },
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b": {
+        "symbol": "M",
+        "decimals": 6
+      }
+    },
+    "BaseSepolia": {
+      "0x437cc33344a0b27a429f795ff6b469c72698b291": {
+        "symbol": "wM",
+        "decimals": 6
+      },
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b": {
+        "symbol": "M",
+        "decimals": 6
+      }
+    },
+    "Solana": {
+      "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp": {
+        "symbol": "",
+        "decimals": 6
+      },
+      "mzeroZRGCah3j5xEWp2Nih3GDejSBbH1rbHoxDg8By6": {
+        "symbol": "",
+        "decimals": 6
+      }
+    }
+  }
+};

--- a/src/m0AutomaticRoute.ts
+++ b/src/m0AutomaticRoute.ts
@@ -54,6 +54,8 @@ import { getExecutorConfig } from "./executor";
 import { SvmRouter } from "./svm";
 import { EvmRouter } from "./evm";
 import { getM0ChainId } from "./chainIds";
+import { hasAnyPath, knownChains } from "./paths";
+import { GENERATED_AT } from "./generated/supportedPaths";
 
 type Op = NttRoute.Options;
 type Tp = routes.TransferParams<Op>;
@@ -105,31 +107,27 @@ export class M0AutomaticRoute<N extends Network>
     return platform == "Evm" || platform == "Solana";
   }
 
+  /**
+   * Derived from the generated path table rather than hand-maintained — a chain
+   * belongs here only if the Portal has at least one live path touching it.
+   */
   static supportedChains(network: Network): Chain[] {
-    switch (network) {
-      case "Mainnet":
-        return ["Ethereum", "Arbitrum", "Base", "Moca", "Solana"];
-      case "Testnet":
-        return [
-          "Sepolia",
-          "ArbitrumSepolia",
-          "BaseSepolia",
-          "Solana",
-        ];
-      default:
-        throw new Error(`Unsupported network: ${network}`);
-    }
+    return knownChains(network);
   }
 
+  /** When the bundled path table was generated, for diagnostics. */
+  static get pathsGeneratedAt(): string {
+    return GENERATED_AT;
+  }
+
+  /**
+   * M0 deploys the Portal and the M/wM tokens at the same addresses on every EVM
+   * chain, so these are resolved by platform. Enumerating chains here instead
+   * would mean this list and `supportedChains` could drift apart.
+   */
   static getContracts(chainContext: ChainContext<Network>): Ntt.Contracts {
-    switch (chainContext.chain) {
-      case "Ethereum":
-      case "Arbitrum":
-      case "Base":
-      case "Moca":
-      case "Sepolia":
-      case "ArbitrumSepolia":
-      case "BaseSepolia":
+    switch (chainToPlatform(chainContext.chain)) {
+      case "Evm":
         return {
           token: "0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b",
           manager: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd",
@@ -147,6 +145,21 @@ export class M0AutomaticRoute<N extends Network>
       default:
         throw new Error(`Unsupported chain: ${chainContext.chain}`);
     }
+  }
+
+  /** Whether the Portal has this exact (source token, chain, destination token) registered. */
+  static async isSupportedPath<N extends Network>(
+    fromChain: ChainContext<N>,
+    toChain: ChainContext<N>,
+    sourceToken: string,
+    destinationToken: string,
+  ): Promise<boolean> {
+    if (chainToPlatform(fromChain.chain) === "Solana") {
+      const router = await SvmRouter.fromChainContext(fromChain);
+      return router.isSupportedPath(sourceToken, toChain.chain, destinationToken);
+    }
+    const router = await EvmRouter.fromChainContext(fromChain);
+    return router.isSupportedPath(sourceToken, toChain.chain, destinationToken);
   }
 
   static async supportedSourceTokens(
@@ -190,44 +203,89 @@ export class M0AutomaticRoute<N extends Network>
     );
   }
 
+  /** Cheap pre-filter: no known path between this pair means nothing to offer. */
+  static isRouteSupported<N extends Network>(
+    fromChain: ChainContext<N>,
+    toChain: ChainContext<N>,
+  ): boolean {
+    return hasAnyPath(fromChain.network, fromChain.chain, toChain.chain);
+  }
+
   getDefaultOptions(): Op {
     return NttRoute.AutomaticOptions;
   }
 
-  async isAvailable(_: routes.RouteTransferRequest<N>): Promise<boolean> {
-    return true;
+  /** The Portal can be paused for sends independently of any path being registered. */
+  async isAvailable(request: routes.RouteTransferRequest<N>): Promise<boolean> {
+    try {
+      const { fromChain } = request;
+      const router =
+        chainToPlatform(fromChain.chain) === "Solana"
+          ? await SvmRouter.fromChainContext(fromChain)
+          : await EvmRouter.fromChainContext(fromChain);
+      return !(await router.isSendPaused());
+    } catch {
+      return false;
+    }
   }
 
   async validate(
     request: routes.RouteTransferRequest<N>,
     params: Tp,
   ): Promise<Vr> {
-    const options = params.options ?? this.getDefaultOptions();
+    try {
+      const options = params.options ?? this.getDefaultOptions();
 
-    const parsedAmount = amount.parse(params.amount, request.source.decimals);
-    // The trimmedAmount may differ from the parsedAmount if the parsedAmount includes dust
-    const trimmedAmount = NttRoute.trimAmount(
-      parsedAmount,
-      request.destination.decimals,
-    );
+      const sourceToken = canonicalAddress(request.source.id);
+      const destinationToken = canonicalAddress(request.destination.id);
 
-    const fromContracts = M0AutomaticRoute.getContracts(request.fromChain);
-    const toContracts = M0AutomaticRoute.getContracts(request.toChain);
+      // `Portal.sendToken` reverts with `UnsupportedBridgingPath` for anything it
+      // has not registered, and it does so after the spend approval has been
+      // signed. Refuse here instead.
+      const supported = await M0AutomaticRoute.isSupportedPath(
+        request.fromChain,
+        request.toChain,
+        sourceToken,
+        destinationToken,
+      );
+      if (!supported) {
+        return {
+          valid: false,
+          params,
+          error: new Error(
+            `Unsupported bridging path: ${request.fromChain.chain}:${sourceToken} -> ` +
+              `${request.toChain.chain}:${destinationToken}`,
+          ),
+        };
+      }
 
-    const validatedParams: Vp = {
-      amount: params.amount,
-      normalizedParams: {
-        amount: trimmedAmount,
-        sourceContracts: fromContracts,
-        destinationContracts: toContracts,
-        options: {
-          queue: false,
-          automatic: true,
+      const parsedAmount = amount.parse(params.amount, request.source.decimals);
+      // The trimmedAmount may differ from the parsedAmount if the parsedAmount includes dust
+      const trimmedAmount = NttRoute.trimAmount(
+        parsedAmount,
+        request.destination.decimals,
+      );
+
+      const fromContracts = M0AutomaticRoute.getContracts(request.fromChain);
+      const toContracts = M0AutomaticRoute.getContracts(request.toChain);
+
+      const validatedParams: Vp = {
+        amount: params.amount,
+        normalizedParams: {
+          amount: trimmedAmount,
+          sourceContracts: fromContracts,
+          destinationContracts: toContracts,
+          options: {
+            queue: false,
+            automatic: true,
+          },
         },
-      },
-      options,
-    };
-    return { valid: true, params: validatedParams };
+        options,
+      };
+      return { valid: true, params: validatedParams };
+    } catch (e) {
+      return { valid: false, params, error: e as Error };
+    }
   }
 
   async quote(

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,98 @@
+import { Chain, Network, TokenId, toNative } from "@wormhole-foundation/sdk-connect";
+import {
+  GeneratedBridgePath,
+  GeneratedTokenInfo,
+  SUPPORTED_PATHS,
+  TOKEN_INFO,
+} from "./generated/supportedPaths";
+
+/**
+ * Read helpers over the generated path table.
+ *
+ * The table is a *candidate* set, refreshed daily from live Portal state. Callers
+ * that are about to offer or execute a transfer must still confirm the path
+ * against the Portal — see `EvmRouter.isSupportedPath`. A stale table can miss a
+ * newly opened path, but it can never make the SDK offer one that would revert.
+ */
+
+/** Tokens are compared case-insensitively; EVM addresses are stored lowercase. */
+function normalize(chain: Chain, token: string): string {
+  return token.startsWith("0x") ? token.toLowerCase() : token;
+}
+
+function pathsFor(network: Network): GeneratedBridgePath[] {
+  return SUPPORTED_PATHS[network] ?? [];
+}
+
+/** Every chain that appears on either end of a known path. */
+export function knownChains(network: Network): Chain[] {
+  const chains = new Set<Chain>();
+  for (const path of pathsFor(network)) {
+    chains.add(path.sourceChain);
+    chains.add(path.destinationChain);
+  }
+  return [...chains].sort();
+}
+
+/** Tokens on `chain` that are the source of at least one known path. */
+export function knownSourceTokens(network: Network, chain: Chain): string[] {
+  const tokens = new Set<string>();
+  for (const path of pathsFor(network)) {
+    if (path.sourceChain === chain) tokens.add(path.sourceToken);
+  }
+  return [...tokens].sort();
+}
+
+/**
+ * Every token seen on `chain`, as either endpoint. Used as the candidate set for
+ * on-chain destination checks — wider than the recorded destinations for a single
+ * source token, so a path opened between refreshes is still discovered.
+ */
+export function knownTokensOn(network: Network, chain: Chain): string[] {
+  const tokens = new Set<string>();
+  for (const path of pathsFor(network)) {
+    if (path.sourceChain === chain) tokens.add(path.sourceToken);
+    if (path.destinationChain === chain) tokens.add(path.destinationToken);
+  }
+  return [...tokens].sort();
+}
+
+/** Destination tokens recorded for this exact route at generation time. */
+export function knownDestinationTokens(
+  network: Network,
+  fromChain: Chain,
+  toChain: Chain,
+  sourceToken: string,
+): string[] {
+  const wanted = normalize(fromChain, sourceToken);
+  const tokens = new Set<string>();
+  for (const path of pathsFor(network)) {
+    if (
+      path.sourceChain === fromChain &&
+      path.destinationChain === toChain &&
+      normalize(fromChain, path.sourceToken) === wanted
+    ) {
+      tokens.add(path.destinationToken);
+    }
+  }
+  return [...tokens].sort();
+}
+
+/** True when the generated table has no knowledge of this chain pair at all. */
+export function hasAnyPath(network: Network, fromChain: Chain, toChain: Chain): boolean {
+  return pathsFor(network).some(
+    (path) => path.sourceChain === fromChain && path.destinationChain === toChain,
+  );
+}
+
+export function tokenInfo(
+  network: Network,
+  chain: Chain,
+  token: string,
+): GeneratedTokenInfo | undefined {
+  return TOKEN_INFO[network]?.[chain]?.[normalize(chain, token)];
+}
+
+export function toTokenIds(chain: Chain, tokens: string[]): TokenId[] {
+  return tokens.map((token) => ({ chain, address: toNative(chain, token) }));
+}

--- a/src/svm.ts
+++ b/src/svm.ts
@@ -40,7 +40,11 @@ type extensionToken = {
 };
 
 export class SvmRouter {
-  private static instance: SvmRouter | null = null;
+  /**
+   * One router per (network, chain) — a bare singleton would let a Mainnet and a
+   * Testnet instance share the same connection and cached path table.
+   */
+  private static instances = new Map<string, SvmRouter>();
   static evmPeer = "0xaCffEC28C4eEe21C889a4e6C0704c540Ed9D4fDd";
 
   constructor(
@@ -56,15 +60,46 @@ export class SvmRouter {
       throw new Error(`Unsupported svm chain: ${ctx.chain}`);
     }
 
-    if (!SvmRouter.instance) {
-      SvmRouter.instance = new SvmRouter(
+    const key = `${ctx.network}:${ctx.chain}`;
+    let instance = SvmRouter.instances.get(key);
+    if (!instance) {
+      instance = new SvmRouter(
         await ctx.getRpc(),
         ctx.chain,
         ctx.network as Exclude<Network, "Devnet">,
       );
+      SvmRouter.instances.set(key, instance);
     }
 
-    return SvmRouter.instance;
+    return instance;
+  }
+
+  /** True when the Portal program has outgoing transfers paused. */
+  async isSendPaused(): Promise<boolean> {
+    try {
+      const program = svmPortalProvider(this.connection);
+      const global = await program.account.portalGlobal.fetch(
+        PublicKey.findProgramAddressSync(
+          [Buffer.from("global")],
+          program.programId,
+        )[0],
+      );
+      return Boolean(global.outgoingPaused);
+    } catch {
+      return false;
+    }
+  }
+
+  /** Whether the Portal has this exact path registered. */
+  async isSupportedPath(
+    sourceToken: string,
+    toChain: Chain,
+    destinationToken: string,
+  ): Promise<boolean> {
+    const destinations = await this.getSupportedDestinationTokens(sourceToken, toChain);
+    return destinations.some(
+      (token) => token.address.toString().toLowerCase() === destinationToken.toLowerCase(),
+    );
   }
 
   async buildSendTokenInstruction(


### PR DESCRIPTION
**Approach A of two.** B is the same fix with a hand-maintained table — see the companion PR. Pick one; they are alternatives, not a stack.

## Problem

`m0AutomaticRoute` never checked whether a bridging route existed. `EvmRouter` returned a hardcoded four-token cross-product and ignored its own `sourceToken` argument, and `validate()` returned `{ valid: true }` unconditionally. The Portal enforces paths at `Portal.sol:447`, so every combination the SDK invented reverted on-chain — after the user had signed the spend approval.

Measured against live state: **168 of 208 advertised mainnet combinations (81%) would revert**, and 78 of 108 on testnet.

It was also under-permissive. A flat, chain-independent token list assumes a token has the same address on every chain. True for M and wM (deterministic deploys), false for M extensions, which are chain-local brands — `USD8` on Moca, `USDHL` on HyperEVM, `mUSD` on Ethereum/BSC/Monad/Linea. Real paths like `MM → Moca:USD8` were inexpressible. Ethereum alone had 25 live paths to supported chains where the SDK could express 15.

## Approach

Candidates are generated from live Portal state; the Portal remains the authority at call time.

`scripts/fetch-supported-paths.ts` enumerates every path from `SupportedBridgingPathSet(address indexed, uint32 indexed, bytes32 indexed, bool)` logs on EVM and `ChainBridgePaths` accounts on Solana. All three key fields are indexed, so the log history is a complete index of Portal route state — confirmed by re-checking all 52 Ethereum entries with `eth_call`, 0 mismatches. Output is `src/generated/supportedPaths.ts`: **81 mainnet paths, 66 testnet**, versus the four hardcoded tokens it replaces.

`EvmRouter.getSupportedDestinationTokens` treats that table as candidates only and re-checks them against the Portal in one Multicall3 round trip (30s cache, per-call fallback where Multicall3 is absent). A stale table can under-report but can never advertise a path that would revert. `validate()` re-checks the exact triple and fails closed.

`.github/workflows/update-supported-paths.yaml` regenerates daily at 05:15 UTC and on manual dispatch (with a `dry_run` input), runs the verifier, discards timestamp-only diffs, adds a changeset, and opens a PR on change.

## Also fixed

- `EvmRouter`/`SvmRouter` keyed by `${network}:${chain}`. A bare singleton handed the second chain touched a provider bound to the first — wrong allowance reads, wrong chain id.
- `isAvailable()` reads `sendPaused()` on EVM, `outgoing_paused` on Solana.
- `supportedChains` and the executor config derive from the same table, so they cannot drift apart.
- `getContracts` resolves by platform rather than a chain whitelist (Portal and M/wM confirmed at identical addresses on every newly reachable chain).
- Added `Bsc: 56` to `chainIds.ts`; BSC had live paths but no entry, so it was unaddressable.

## Verification

`pnpm verify:paths` compares what the SDK offers against a direct `supportedBridgingPath` read for every pair it can produce, and gates the workflow.

```
Mainnet  144 pairs, 79 destination tokens offered, 0 mismatches
Testnet   32 pairs, 64 destination tokens offered, 0 mismatches
```

## Trade-off vs B

No maintenance — new extensions and chains appear on their own. It already surfaced live paths on BSC, Linea, Monad, HyperEVM and Moca that the SDK did not know existed. Cost is roughly 650 lines of tooling plus a generated file, and RPC secrets in CI.

## Known limits

- Routable chains are bounded by the Wormhole `Chain` union in the pinned `sdk-base` (4.9.1), since transfers travel over the Wormhole adapter. Soneium, Citrea, RISE, MANTRA, Fluent, Seismic and Nexus have live Portal paths but no Wormhole chain there — dropped with a warning. Reaching them needs a `sdk-base` bump.
- Chains whose RPC caps `getLogs` (Moca at 10k blocks, Monad at 1k) fall back to Multicall3 probing, which only finds tokens seen on other chains. Reported per run, not silent.
- Plasma produced zero paths — nothing inbound from any scanned chain, so the probe had no candidates. Worth confirming whether it should be live.
- `quote()` still returns a hardcoded `relayFee` of 1,500,000 base units while `initiate()` charges the real executor quote. Orthogonal to route validity; not touched here.

## Before merging

Set the RPC secrets the workflow reads (`ETHEREUM_RPC_URL`, `MOCA_RPC_URL`, …). Without them it falls back to public endpoints, which push more chains onto the weaker probe path.
