### PR TITLE
feat: resolve bridging paths from Portal state (B: static token table)

### DIFF
--- a/.changeset/static-supported-paths.md
+++ b/.changeset/static-supported-paths.md
@@ -1,0 +1,14 @@
+---
+"@m0-foundation/ntt-sdk-route": minor
+---
+
+Only offer bridging paths the Portal actually accepts.
+
+Destination tokens are now resolved against `supportedBridgingPath` instead of a
+hardcoded token cross-product, and `validate()` re-checks the exact
+(source token, chain, destination token) triple before quoting. Candidates come
+from a per-chain token list in `src/tokens.ts`.
+
+Also fixes `EvmRouter`/`SvmRouter` returning a router bound to the first chain
+touched, adds BSC to the chain id map, and makes `isAvailable()` honour the
+Portal's send pause.

--- a/src/chainIds.ts
+++ b/src/chainIds.ts
@@ -12,6 +12,7 @@ export function getM0ChainId(chain: Chain, network: Network): number {
     Avalanche: 43114,
     Base: 8453,
     Berachain: 80094,
+    Bsc: 56,
     Ethereum: 1,
     HyperEVM: 999,
     Ink: 57073,

--- a/src/evm.ts
+++ b/src/evm.ts
@@ -4,31 +4,39 @@ import {
   chainToPlatform,
   Network,
   TokenId,
-  toNative,
 } from "@wormhole-foundation/sdk-connect";
 import { Contract, ContractTransaction, type Provider } from "ethers";
 import { evmPortalProvider } from "./artifacts";
 import { getM0ChainId } from "./chainIds";
 import { NttWithExecutor } from "@wormhole-foundation/sdk-definitions-ntt";
 import { PublicKey } from "@solana/web3.js";
+import { knownSourceTokens, knownTokensOn, toTokenIds } from "./tokens";
 
 const ERC20_ABI = [
   "function allowance(address owner, address spender) view returns (uint256)",
   "function approve(address spender, uint256 amount) returns (bool)",
 ];
 
+const MULTICALL3_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11";
+const MULTICALL3_ABI = [
+  "function aggregate3((address target, bool allowFailure, bytes callData)[] calls) view returns ((bool success, bytes returnData)[])",
+];
+
+/** How long a resolved destination-token set stays warm. */
+const PATH_CACHE_TTL_MS = 30_000;
+
 export class EvmRouter {
-  private static instance: EvmRouter | null = null;
+  /**
+   * One router per (network, chain). A bare singleton would hand the second chain
+   * touched a provider bound to the first, silently reading balances and
+   * allowances from the wrong chain.
+   */
+  private static instances = new Map<string, EvmRouter>();
 
   private WORMHOLE_ADAPTER = "0xaCffEC28C4eEe21C889a4e6C0704c540Ed9D4fDd";
   private static PORTAL_ADDRESS = "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd";
 
-  private TOKENS = [
-    "0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b", // $M
-    "0xdb1C440386b864181C77c02A51b7f4F6dD840dF4", // $MM
-    "0x437cc33344a0B27A429f795ff6B469C72698B291", // wM
-    "0xA4B6DF229AEe22b4252dc578FEB2720E8A2C4A56", // USDZ
-  ];
+  private pathCache = new Map<string, { expiresAt: number; tokens: string[] }>();
 
   constructor(
     private provider: Provider,
@@ -36,46 +44,119 @@ export class EvmRouter {
     public network: Exclude<Network, "Devnet">,
   ) {}
 
-  async getSupportedSourceTokens(): Promise<TokenId[]> {
-    return this.TOKENS.map((token) => ({
-      chain: this.chain,
-      address: toNative(this.chain, token),
-    }));
-  }
-
-  async getSupportedDestinationTokens(
-    _sourceToken: string,
-    toChain: Chain,
-  ): Promise<TokenId[]> {
-    if (toChain === "Solana") {
-      return [
-        {
-          chain: toChain,
-          address: toNative(toChain, "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp"),
-        },
-      ];
-    }
-
-    return this.TOKENS.map((token) => ({
-      chain: toChain,
-      address: toNative(toChain, token),
-    }));
-  }
-
   static async fromChainContext(ctx: ChainContext<Network>) {
     if (chainToPlatform(ctx.chain) !== "Evm") {
       throw new Error(`Unsupported evm chain: ${ctx.chain}`);
     }
 
-    if (!EvmRouter.instance) {
-      EvmRouter.instance = new EvmRouter(
+    const key = `${ctx.network}:${ctx.chain}`;
+    let instance = EvmRouter.instances.get(key);
+    if (!instance) {
+      instance = new EvmRouter(
         await ctx.getRpc(),
         ctx.chain,
         ctx.network as Exclude<Network, "Devnet">,
       );
+      EvmRouter.instances.set(key, instance);
     }
 
-    return EvmRouter.instance;
+    return instance;
+  }
+
+  async getSupportedSourceTokens(): Promise<TokenId[]> {
+    return toTokenIds(this.chain, knownSourceTokens(this.network, this.chain));
+  }
+
+  /**
+   * Destination tokens the Portal will actually accept for `sourceToken`.
+   *
+   * Candidates come from `src/tokens.ts`; the answer comes from the Portal.
+   * `Portal.sendToken` reverts with `UnsupportedBridgingPath` for anything not
+   * registered, so returning an unchecked list makes the route resolve for
+   * transfers that cannot succeed.
+   */
+  async getSupportedDestinationTokens(
+    sourceToken: string,
+    toChain: Chain,
+  ): Promise<TokenId[]> {
+    const cacheKey = `${sourceToken.toLowerCase()}:${toChain}`;
+    const cached = this.pathCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return toTokenIds(toChain, cached.tokens);
+    }
+
+    const candidates = knownTokensOn(this.network, toChain);
+    if (candidates.length === 0) return [];
+
+    const supported = await this.filterSupportedPaths(sourceToken, toChain, candidates);
+    this.pathCache.set(cacheKey, {
+      expiresAt: Date.now() + PATH_CACHE_TTL_MS,
+      tokens: supported,
+    });
+
+    return toTokenIds(toChain, supported);
+  }
+
+  /** Narrows `candidates` to those registered on the Portal, in one Multicall3 round trip. */
+  async filterSupportedPaths(
+    sourceToken: string,
+    toChain: Chain,
+    candidates: string[],
+  ): Promise<string[]> {
+    const portal = evmPortalProvider(this.provider);
+    const destinationChainId = getM0ChainId(toChain, this.network);
+
+    const calls = candidates.map((token) => ({
+      target: EvmRouter.PORTAL_ADDRESS,
+      allowFailure: true,
+      callData: portal.interface.encodeFunctionData("supportedBridgingPath", [
+        sourceToken,
+        destinationChainId,
+        EvmRouter.stringToBytes32(token),
+      ]),
+    }));
+
+    try {
+      const multicall = new Contract(MULTICALL3_ADDRESS, MULTICALL3_ABI, this.provider);
+      const results: Array<{ success: boolean; returnData: string }> =
+        await multicall.aggregate3(calls);
+      return candidates.filter((_, i) => {
+        const result = results[i];
+        return !!result?.success && BigInt(result.returnData) === 1n;
+      });
+    } catch {
+      // No Multicall3, or the call was rejected — fall back to individual reads
+      // rather than returning an unchecked list.
+      const checks = await Promise.all(
+        candidates.map((token) => this.isSupportedPath(sourceToken, toChain, token)),
+      );
+      return candidates.filter((_, i) => checks[i]);
+    }
+  }
+
+  /** Single-path check, used to gate a transfer immediately before quoting it. */
+  async isSupportedPath(
+    sourceToken: string,
+    toChain: Chain,
+    destinationToken: string,
+  ): Promise<boolean> {
+    try {
+      return await evmPortalProvider(this.provider).supportedBridgingPath(
+        sourceToken,
+        getM0ChainId(toChain, this.network),
+        EvmRouter.stringToBytes32(destinationToken),
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  async isSendPaused(): Promise<boolean> {
+    try {
+      return await evmPortalProvider(this.provider).sendPaused();
+    } catch {
+      return false;
+    }
   }
 
   async buildSendTokenTransaction(
@@ -89,7 +170,6 @@ export class EvmRouter {
   ): Promise<ContractTransaction> {
     const portal = evmPortalProvider(this.provider);
 
-    const recipientBytes32 = EvmRouter.stringToBytes32(recipient);
     const destinationTokenBytes32 = EvmRouter.stringToBytes32(destinationToken);
 
     const tx = await portal

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,15 +1,17 @@
 import { Chain, Network } from "@wormhole-foundation/sdk-connect";
 import { NttExecutorRoute, NttRoute } from "@wormhole-foundation/sdk-route-ntt";
 import { PublicKey } from "@solana/web3.js";
+import { chainToPlatform } from "@wormhole-foundation/sdk-connect";
+import { knownChains } from "./tokens";
 
 export function getExecutorConfig(
   network: Network = "Mainnet",
 ): NttExecutorRoute.Config {
-  const svmChains: Chain[] = ["Solana"];
-  const evmChains: Chain[] =
-    network === "Mainnet"
-      ? ["Ethereum", "Arbitrum", "Base", "Moca"]
-      : ["Sepolia", "ArbitrumSepolia", "BaseSepolia"];
+  // Derived from SUPPORTED_CHAINS so this cannot drift from
+  // `M0AutomaticRoute.supportedChains`.
+  const supported = knownChains(network);
+  const svmChains: Chain[] = supported.filter((c) => chainToPlatform(c) === "Solana");
+  const evmChains: Chain[] = supported.filter((c) => chainToPlatform(c) === "Evm");
 
   const evmMToken = "0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b";
   const evmOverrides = Object.fromEntries(

--- a/src/m0AutomaticRoute.ts
+++ b/src/m0AutomaticRoute.ts
@@ -54,6 +54,7 @@ import { getExecutorConfig } from "./executor";
 import { SvmRouter } from "./svm";
 import { EvmRouter } from "./evm";
 import { getM0ChainId } from "./chainIds";
+import { hasAnyPath, knownChains } from "./tokens";
 
 type Op = NttRoute.Options;
 type Tp = routes.TransferParams<Op>;
@@ -105,31 +106,19 @@ export class M0AutomaticRoute<N extends Network>
     return platform == "Evm" || platform == "Solana";
   }
 
+  /** Kept in `src/tokens.ts` alongside the token list it must stay in step with. */
   static supportedChains(network: Network): Chain[] {
-    switch (network) {
-      case "Mainnet":
-        return ["Ethereum", "Arbitrum", "Base", "Moca", "Solana"];
-      case "Testnet":
-        return [
-          "Sepolia",
-          "ArbitrumSepolia",
-          "BaseSepolia",
-          "Solana",
-        ];
-      default:
-        throw new Error(`Unsupported network: ${network}`);
-    }
+    return knownChains(network);
   }
 
+  /**
+   * M0 deploys the Portal and the M/wM tokens at the same addresses on every EVM
+   * chain, so these are resolved by platform. Enumerating chains here instead
+   * would mean this list and `supportedChains` could drift apart.
+   */
   static getContracts(chainContext: ChainContext<Network>): Ntt.Contracts {
-    switch (chainContext.chain) {
-      case "Ethereum":
-      case "Arbitrum":
-      case "Base":
-      case "Moca":
-      case "Sepolia":
-      case "ArbitrumSepolia":
-      case "BaseSepolia":
+    switch (chainToPlatform(chainContext.chain)) {
+      case "Evm":
         return {
           token: "0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b",
           manager: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd",
@@ -147,6 +136,21 @@ export class M0AutomaticRoute<N extends Network>
       default:
         throw new Error(`Unsupported chain: ${chainContext.chain}`);
     }
+  }
+
+  /** Whether the Portal has this exact (source token, chain, destination token) registered. */
+  static async isSupportedPath<N extends Network>(
+    fromChain: ChainContext<N>,
+    toChain: ChainContext<N>,
+    sourceToken: string,
+    destinationToken: string,
+  ): Promise<boolean> {
+    if (chainToPlatform(fromChain.chain) === "Solana") {
+      const router = await SvmRouter.fromChainContext(fromChain);
+      return router.isSupportedPath(sourceToken, toChain.chain, destinationToken);
+    }
+    const router = await EvmRouter.fromChainContext(fromChain);
+    return router.isSupportedPath(sourceToken, toChain.chain, destinationToken);
   }
 
   static async supportedSourceTokens(
@@ -190,44 +194,89 @@ export class M0AutomaticRoute<N extends Network>
     );
   }
 
+  /** Cheap pre-filter: no known path between this pair means nothing to offer. */
+  static isRouteSupported<N extends Network>(
+    fromChain: ChainContext<N>,
+    toChain: ChainContext<N>,
+  ): boolean {
+    return hasAnyPath(fromChain.network, fromChain.chain, toChain.chain);
+  }
+
   getDefaultOptions(): Op {
     return NttRoute.AutomaticOptions;
   }
 
-  async isAvailable(_: routes.RouteTransferRequest<N>): Promise<boolean> {
-    return true;
+  /** The Portal can be paused for sends independently of any path being registered. */
+  async isAvailable(request: routes.RouteTransferRequest<N>): Promise<boolean> {
+    try {
+      const { fromChain } = request;
+      const router =
+        chainToPlatform(fromChain.chain) === "Solana"
+          ? await SvmRouter.fromChainContext(fromChain)
+          : await EvmRouter.fromChainContext(fromChain);
+      return !(await router.isSendPaused());
+    } catch {
+      return false;
+    }
   }
 
   async validate(
     request: routes.RouteTransferRequest<N>,
     params: Tp,
   ): Promise<Vr> {
-    const options = params.options ?? this.getDefaultOptions();
+    try {
+      const options = params.options ?? this.getDefaultOptions();
 
-    const parsedAmount = amount.parse(params.amount, request.source.decimals);
-    // The trimmedAmount may differ from the parsedAmount if the parsedAmount includes dust
-    const trimmedAmount = NttRoute.trimAmount(
-      parsedAmount,
-      request.destination.decimals,
-    );
+      const sourceToken = canonicalAddress(request.source.id);
+      const destinationToken = canonicalAddress(request.destination.id);
 
-    const fromContracts = M0AutomaticRoute.getContracts(request.fromChain);
-    const toContracts = M0AutomaticRoute.getContracts(request.toChain);
+      // `Portal.sendToken` reverts with `UnsupportedBridgingPath` for anything it
+      // has not registered, and it does so after the spend approval has been
+      // signed. Refuse here instead.
+      const supported = await M0AutomaticRoute.isSupportedPath(
+        request.fromChain,
+        request.toChain,
+        sourceToken,
+        destinationToken,
+      );
+      if (!supported) {
+        return {
+          valid: false,
+          params,
+          error: new Error(
+            `Unsupported bridging path: ${request.fromChain.chain}:${sourceToken} -> ` +
+              `${request.toChain.chain}:${destinationToken}`,
+          ),
+        };
+      }
 
-    const validatedParams: Vp = {
-      amount: params.amount,
-      normalizedParams: {
-        amount: trimmedAmount,
-        sourceContracts: fromContracts,
-        destinationContracts: toContracts,
-        options: {
-          queue: false,
-          automatic: true,
+      const parsedAmount = amount.parse(params.amount, request.source.decimals);
+      // The trimmedAmount may differ from the parsedAmount if the parsedAmount includes dust
+      const trimmedAmount = NttRoute.trimAmount(
+        parsedAmount,
+        request.destination.decimals,
+      );
+
+      const fromContracts = M0AutomaticRoute.getContracts(request.fromChain);
+      const toContracts = M0AutomaticRoute.getContracts(request.toChain);
+
+      const validatedParams: Vp = {
+        amount: params.amount,
+        normalizedParams: {
+          amount: trimmedAmount,
+          sourceContracts: fromContracts,
+          destinationContracts: toContracts,
+          options: {
+            queue: false,
+            automatic: true,
+          },
         },
-      },
-      options,
-    };
-    return { valid: true, params: validatedParams };
+        options,
+      };
+      return { valid: true, params: validatedParams };
+    } catch (e) {
+      return { valid: false, params, error: e as Error };
+    }
   }
 
   async quote(

--- a/src/svm.ts
+++ b/src/svm.ts
@@ -40,7 +40,11 @@ type extensionToken = {
 };
 
 export class SvmRouter {
-  private static instance: SvmRouter | null = null;
+  /**
+   * One router per (network, chain) — a bare singleton would let a Mainnet and a
+   * Testnet instance share the same connection and cached path table.
+   */
+  private static instances = new Map<string, SvmRouter>();
   static evmPeer = "0xaCffEC28C4eEe21C889a4e6C0704c540Ed9D4fDd";
 
   constructor(
@@ -56,15 +60,46 @@ export class SvmRouter {
       throw new Error(`Unsupported svm chain: ${ctx.chain}`);
     }
 
-    if (!SvmRouter.instance) {
-      SvmRouter.instance = new SvmRouter(
+    const key = `${ctx.network}:${ctx.chain}`;
+    let instance = SvmRouter.instances.get(key);
+    if (!instance) {
+      instance = new SvmRouter(
         await ctx.getRpc(),
         ctx.chain,
         ctx.network as Exclude<Network, "Devnet">,
       );
+      SvmRouter.instances.set(key, instance);
     }
 
-    return SvmRouter.instance;
+    return instance;
+  }
+
+  /** True when the Portal program has outgoing transfers paused. */
+  async isSendPaused(): Promise<boolean> {
+    try {
+      const program = svmPortalProvider(this.connection);
+      const global = await program.account.portalGlobal.fetch(
+        PublicKey.findProgramAddressSync(
+          [Buffer.from("global")],
+          program.programId,
+        )[0],
+      );
+      return Boolean(global.outgoingPaused);
+    } catch {
+      return false;
+    }
+  }
+
+  /** Whether the Portal has this exact path registered. */
+  async isSupportedPath(
+    sourceToken: string,
+    toChain: Chain,
+    destinationToken: string,
+  ): Promise<boolean> {
+    const destinations = await this.getSupportedDestinationTokens(sourceToken, toChain);
+    return destinations.some(
+      (token) => token.address.toString().toLowerCase() === destinationToken.toLowerCase(),
+    );
   }
 
   async buildSendTokenInstruction(

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,0 +1,126 @@
+import { Chain, Network, TokenId, toNative } from "@wormhole-foundation/sdk-connect";
+
+/**
+ * Tokens the Portal can bridge, per chain.
+ *
+ * MAINTAINED BY HAND. Add an entry whenever an M extension is deployed or a new
+ * chain is onboarded — nothing detects a missing one. An absent token is not an
+ * error; the route simply never appears.
+ *
+ * This is a candidate list only. `EvmRouter` re-checks each entry against
+ * `Portal.supportedBridgingPath` before offering it, so a token listed here that
+ * has no live path is pruned rather than shown. Listing a token is therefore safe;
+ * omitting one is what costs you a route.
+ *
+ * EVM addresses are lowercase; Solana entries are base58 mints. M and wM share
+ * one address across EVM chains (deterministic deploys) but extensions do not —
+ * they are chain-local brands, so each chain lists its own.
+ */
+export const TOKENS: Record<string, Partial<Record<Chain, string[]>>> = {
+  Mainnet: {
+    Arbitrum: [
+      "0x437cc33344a0b27a429f795ff6b469c72698b291", // wM
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b", // M
+      "0xa4b6df229aee22b4252dc578feb2720e8a2c4a56", // USDZ
+    ],
+    Base: [
+      "0x437cc33344a0b27a429f795ff6b469c72698b291", // wM
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b", // M
+    ],
+    Bsc: [
+      "0xaca92e438df0b2401ff60da7e4337b687a2435da", // mUSD
+    ],
+    Ethereum: [
+      "0x437cc33344a0b27a429f795ff6b469c72698b291", // wM
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b", // M
+      "0xa4b6df229aee22b4252dc578feb2720e8a2c4a56", // USDZ
+      "0xaca92e438df0b2401ff60da7e4337b687a2435da", // mUSD
+      "0xdb1c440386b864181c77c02a51b7f4f6dd840df4", // MM
+    ],
+    HyperEVM: [
+      "0xb50a96253abdf803d85efcdce07ad8becbc52bd5", // USDHL
+    ],
+    Linea: [
+      "0xaca92e438df0b2401ff60da7e4337b687a2435da", // mUSD
+    ],
+    Moca: [
+      "0x437cc33344a0b27a429f795ff6b469c72698b291", // wM
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b", // M
+      "0x911c64b221d3509f4fe27a352d12d8a0615d0674", // USD8
+    ],
+    Monad: [
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b", // M
+      "0xaca92e438df0b2401ff60da7e4337b687a2435da", // mUSD
+    ],
+    Solana: [
+      "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp", // wM (M0 extension)
+      "mzeroZRGCah3j5xEWp2Nih3GDejSBbH1rbHoxDg8By6", // M0 extension
+      "mzerokyEX9TNDoK4o2YZQBDmMzjokAeN6M2g2S3pLJo", // M0 extension
+      "usdkbee86pkLyRmxfFCdkyySpxRb5ndCxVsK2BkRXwX", // M0 extension
+      "usdkyPPxgV7sfNyKb8eDz66ogPrkRXG3wS2FVb6LLUf", // M0 extension
+      "xoUSD7HdezER6vVPbYETEpPR3G7CsCgzWioiDezxDsg", // M0 extension
+      "xoUSDGZKvRqNK11R4KwYofahwCybp9VXTjuvRDSjFsV", // M0 extension
+      "xoUSDq85Rjsb6SbUwJyreFgeWQvxdkT7R3c3g7s6p5Y", // M0 extension
+    ],
+  },
+  Testnet: {
+    ArbitrumSepolia: [
+      "0x437cc33344a0b27a429f795ff6b469c72698b291", // wM
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b", // M
+    ],
+    BaseSepolia: [
+      "0x437cc33344a0b27a429f795ff6b469c72698b291", // wM
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b", // M
+    ],
+    OptimismSepolia: [
+      "0x437cc33344a0b27a429f795ff6b469c72698b291", // wM
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b", // M
+    ],
+    Sepolia: [
+      "0x437cc33344a0b27a429f795ff6b469c72698b291", // wM
+      "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b", // M
+    ],
+    Solana: [
+      "mzeroXDoBpRVhnEXBra27qzAMdxgpWVY3DzQW7xMVJp", // wM (M0 extension)
+      "mzeroZRGCah3j5xEWp2Nih3GDejSBbH1rbHoxDg8By6", // M0 extension
+    ],
+  },
+};
+
+/**
+ * Chains this route can bridge between. Must stay in step with `TOKENS` above —
+ * a chain listed here with no tokens offers nothing, and a chain with tokens but
+ * missing here is unreachable.
+ */
+export const SUPPORTED_CHAINS: Record<string, Chain[]> = {
+  Mainnet: ["Arbitrum", "Base", "Bsc", "Ethereum", "HyperEVM", "Linea", "Moca", "Monad", "Solana"],
+  Testnet: ["ArbitrumSepolia", "BaseSepolia", "OptimismSepolia", "Sepolia", "Solana"],
+};
+
+export function knownChains(network: Network): Chain[] {
+  return SUPPORTED_CHAINS[network] ?? [];
+}
+
+/** Candidate source tokens on `chain`; narrowed against the Portal before use. */
+export function knownSourceTokens(network: Network, chain: Chain): string[] {
+  return TOKENS[network]?.[chain] ?? [];
+}
+
+/**
+ * Candidate destination tokens on `chain`. Identical to the source list — without
+ * a path table there is no way to tell which pairings exist, so every token on the
+ * destination chain is a candidate and the on-chain check decides.
+ */
+export function knownTokensOn(network: Network, chain: Chain): string[] {
+  return TOKENS[network]?.[chain] ?? [];
+}
+
+/** Both endpoints supported. Whether a path exists between them is decided on-chain. */
+export function hasAnyPath(network: Network, fromChain: Chain, toChain: Chain): boolean {
+  const chains = knownChains(network);
+  return chains.includes(fromChain) && chains.includes(toChain);
+}
+
+export function toTokenIds(chain: Chain, tokens: string[]): TokenId[] {
+  return tokens.map((token) => ({ chain, address: toNative(chain, token) }));
+}


### PR DESCRIPTION

## Problem

We do not currently constrain automatic routes to only Portal supported bridging paths. This PR seeks to change that.

## Approach

`src/tokens.ts` replaces the flat list with a per-chain one, and `EvmRouter.getSupportedDestinationTokens` re-checks every candidate against `Portal.supportedBridgingPath` in one Multicall3 round trip before offering it (30s cache, per-call fallback where Multicall3 is absent). `validate()` re-checks the exact triple and fails closed.

The asymmetry that matters when maintaining the file: **listing a token that has no live path is harmless** — the on-chain check prunes it. **Omitting one costs a route, and nothing detects that.** No error, no warning; the route simply never appears. So the file must be updated by hand whenever an M extension is deployed or a chain is onboarded.

## Also fixed

- `EvmRouter`/`SvmRouter` keyed by `${network}:${chain}`. A bare singleton handed the second chain touched a provider bound to the first.
- `isAvailable()` reads `sendPaused()` on EVM, `outgoing_paused` on Solana.
- `supportedChains` and the executor config derive from `SUPPORTED_CHAINS`, so they cannot drift apart.
- `getContracts` resolves by platform rather than a chain whitelist (Portal and M/wM confirmed at identical addresses on every newly reachable chain).
- Added `Bsc: 56` to `chainIds.ts`; BSC had live paths but no entry, so it was unaddressable.

## Verification

Checked against live chain state — for every pair the SDK can produce, what it offers was compared to a direct `supportedBridgingPath` read